### PR TITLE
Add token view and model family selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "gpt-token-counter" extension will be documented in this file.
 
+## [1.3.0]
+
+### Added
+- Token View option for highlighting tokens with alternating colors.
+- Model menu simplified to use model families.
+
 ## [1.2.5]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
     <h1>Live LLM Token Counter</h1>
     <img src="images/icon.png" alt="Logo" width="300" height="300"><br>
-    <a href="https://marketplace.visualstudio.com/items?itemName=bedirt.gpt-token-counter-live"><img src="https://img.shields.io/badge/VSCode-v1.2.5-blue?style=flat&logo=visualstudiocode" alt="VSCode Version"></a>
-    <a href="https://open-vsx.org/extension/bedirt/gpt-token-counter-live"><img alt="OpenVSX Version" src="https://img.shields.io/badge/OpenVSX%20-%20v1.2.5%20-%20%23bb3ec2?style=flat"></a>
+    <a href="https://marketplace.visualstudio.com/items?itemName=bedirt.gpt-token-counter-live"><img src="https://img.shields.io/badge/VSCode-v1.3.0-blue?style=flat&logo=visualstudiocode" alt="VSCode Version"></a>
+    <a href="https://open-vsx.org/extension/bedirt/gpt-token-counter-live"><img alt="OpenVSX Version" src="https://img.shields.io/badge/OpenVSX%20-%20v1.3.0%20-%20%23bb3ec2?style=flat"></a>
     <br><br>
 </div>
 
@@ -20,8 +20,9 @@ https://github.com/BedirT/LLM-Token-Counter-VSCode/assets/10860127/d250f139-b1b1
 
 - **Easy Activation:** The extension is activated as soon as VS Code starts up, so you don't have to manually activate it every time you start your editor.
 
-- **Model Selection:** The extension allows you to select the model you want to use for token counting. The default model is the OpenAI's GPT-4 model. All OpenAI and Anthropic models are available. You can change the model by clicking on the token count in the status bar and selecting the model you want to use.
-  - **Note:** Claude models (marked with *) use an approximate token counter as Anthropic doesn't provide an exact tokenizer for Claude-3.5 and Claude-3.7 models.
+- **Model Family Selection:** Instead of individual models, you can select the model family. Families share the same tokenizer so the list is shorter.
+  - **Note:** Claude and Gemini families (marked with *) use an approximate token counter as there is no exact tokenizer.
+- **Token View:** An optional token view highlights tokens using two alternating colors. Activate it from the same menu to visualise tokens for the current selection or the entire document when no text is selected.
 
 https://github.com/BedirT/LLM-Token-Counter-VSCode/assets/10860127/5dffabb0-28c2-49cb-aeb2-4c8d2a62b047
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gpt-token-counter-live",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gpt-token-counter-live",
-      "version": "1.2.5",
+      "version": "1.3.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gpt-token-counter-live",
   "displayName": "Live LLM Token Counter",
   "description": "Live Token Counter for Language Models",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "publisher": "bedirt",
   "author": {
     "name": "BedirT"

--- a/src/extension.js
+++ b/src/extension.js
@@ -11,45 +11,60 @@ function activate(context) {
     let statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
     statusBar.command = "gpt-token-counter-live.changeModel";
 
-    const modelProviders = {
+    const modelFamilies = {
         'openai': [
-            'o3-mini',
+            'o3',
             'o1',
-            'o1-mini',
             'gpt-4o',
-            'gpt-4o-mini',
             'gpt-4',
-            'gpt-3.5-turbo',
+            'gpt-3.5',
         ],
         'anthropic': [
-            'claude-3.5*', // There is no exact tokenizer for claude-3
+            'claude-4*',
             'claude-3.7*',
+            'claude-3.5*',
+        ],
+        'google': [
+            'gemini*'
         ]
     };
 
     const specialTokens = {
-        'o3-mini': ['<|endoftext|>'],
+        'o3': ['<|endoftext|>'],
         'o1': ['<|endoftext|>'],
-        'o1-mini': ['<|endoftext|>'],
         'gpt-4o': ['<|endoftext|>'],
-        'gpt-4o-mini': ['<|endoftext|>'],
         'gpt-4': ['<|endoftext|>'],
-        'gpt-3.5-turbo': ['<|endoftext|>'],
-        'claude-3.5*': [], // Approximate
+        'gpt-3.5': ['<|endoftext|>'],
+        'claude-4*': [], // Approximate
         'claude-3.7*': [], // Approximate
+        'claude-3.5*': [], // Approximate
+        'gemini*': [], // Approximate
     };
 
-    let currentModel = modelProviders.openai[0];
+    const familyToModel = {
+        'o3': 'o3-mini',
+        'o1': 'o1',
+        'gpt-4o': 'gpt-4o',
+        'gpt-4': 'gpt-4',
+        'gpt-3.5': 'gpt-3.5-turbo',
+        'claude-4*': 'claude-3.7*',
+        'claude-3.7*': 'claude-3.7*',
+        'claude-3.5*': 'claude-3.5*',
+        'gemini*': 'cl100k_base'
+    };
+
+    let currentModel = modelFamilies.openai[0];
     let currentProvider = 'openai';
 
     context.subscriptions.push(statusBar);
 
     // Function to initialize the encoder
     function initializeEncoder(model) {
+        const base = familyToModel[model] || model;
         if (encoder) {
             encoder.free();
         }
-        encoder = encoding_for_model(model);
+        encoder = encoding_for_model(base);
     }
 
     // Function to handle special tokens
@@ -89,24 +104,87 @@ function activate(context) {
 
         statusBar.text = `Token Count: ${tokenCount} (${currentModel})`;
         statusBar.show();
+        highlightTokens();
     };
 
     vscode.window.onDidChangeTextEditorSelection(updateTokenCount, null, context.subscriptions);
     vscode.window.onDidChangeActiveTextEditor(updateTokenCount, null, context.subscriptions);
     vscode.workspace.onDidChangeTextDocument(updateTokenCount, null, context.subscriptions);
 
+    let tokenViewEnabled = false;
+    const decorationTypeA = vscode.window.createTextEditorDecorationType({ backgroundColor: 'rgba(255, 215, 0, 0.2)' });
+    const decorationTypeB = vscode.window.createTextEditorDecorationType({ backgroundColor: 'rgba(173, 216, 230, 0.2)' });
+
+    function clearHighlights(editor) {
+        if (!editor) { return; }
+        editor.setDecorations(decorationTypeA, []);
+        editor.setDecorations(decorationTypeB, []);
+    }
+
+    function highlightTokens() {
+        let editor = vscode.window.activeTextEditor;
+        if (!editor || !tokenViewEnabled) {
+            clearHighlights(editor);
+            return;
+        }
+
+        let document = editor.document;
+        let selection = editor.selection;
+        let text = selection.isEmpty ? document.getText() : document.getText(selection);
+        let startOffset = selection.isEmpty ? 0 : document.offsetAt(selection.start);
+
+        let tokens = [];
+        let decode;
+        if (currentProvider === 'anthropic') {
+            const { getTokenizer } = require('@anthropic-ai/tokenizer');
+            const tok = getTokenizer();
+            tokens = Array.from(tok.encode(text, 'all'));
+            decode = t => Buffer.from(tok.decode_single_token_bytes(t)).toString();
+            tok.free();
+        } else if (encoder) {
+            tokens = Array.from(encoder.encode(text));
+            decode = t => Buffer.from(encoder.decode_single_token_bytes(t)).toString();
+        }
+
+        let decoA = [], decoB = [];
+        let offset = 0;
+        let useA = true;
+        for (let tok of tokens) {
+            let str = decode(tok);
+            let start = document.positionAt(startOffset + offset);
+            offset += str.length;
+            let end = document.positionAt(startOffset + offset);
+            let range = new vscode.Range(start, end);
+            if (useA) {
+                decoA.push({ range });
+            } else {
+                decoB.push({ range });
+            }
+            useA = !useA;
+        }
+        editor.setDecorations(decorationTypeA, decoA);
+        editor.setDecorations(decorationTypeB, decoB);
+    }
+
     let disposable = vscode.commands.registerCommand('gpt-token-counter-live.changeModel', async function () {
-        let flatModelList = Object.entries(modelProviders).reduce((acc, [provider, models]) => acc.concat(models.map(model => `${provider}: ${model}`)), []);
+        let flatModelList = Object.entries(modelFamilies).reduce((acc, [provider, models]) => acc.concat(models.map(model => `${provider}: ${model}`)), []);
+        const toggleLabel = `Toggle Token View (${tokenViewEnabled ? 'On' : 'Off'})`;
+        flatModelList.push(toggleLabel);
         let selection = await vscode.window.showQuickPick(flatModelList, {
-            placeHolder: 'Select a Model',
+            placeHolder: 'Select a Model Family or Option',
         });
 
         if (selection) {
+            if (selection === toggleLabel) {
+                tokenViewEnabled = !tokenViewEnabled;
+                highlightTokens();
+                return;
+            }
             const [provider, model] = selection.split(': ');
             currentProvider = provider;
             currentModel = model;
 
-            if (currentProvider === 'openai') {
+            if (currentProvider === 'openai' || currentProvider === 'google') {
                 try {
                     initializeEncoder(currentModel);
                 } catch (error) {
@@ -116,6 +194,7 @@ function activate(context) {
             }
 
             updateTokenCount();
+            highlightTokens();
         }
     });
 
@@ -124,6 +203,7 @@ function activate(context) {
     // Initial update
     initializeEncoder(currentModel);
     updateTokenCount();
+    highlightTokens();
 }
 
 function deactivate() {


### PR DESCRIPTION
## Summary
- enable alternating two-color token highlight via new Token View option
- reduce model selection to model families and add Gemini family
- document new feature in README and changelog
- bump version to 1.3.0

## Testing
- `npm run lint`
- `npm test` *(fails: runs but produces no output)*