### PR TITLE
feat: add file pattern filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ All notable changes to the "gpt-token-counter" extension will be documented in t
 ### Added
 - New setting `enabledFilePatterns` to show status bar only for files matching specific glob patterns (e.g., `["*.md", "*.mdc"]`).
 
-## [1.4.0]
-
-### Added
-- Token highlighting feature with configurable colors.
-
 ## [1.3.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the "gpt-token-counter" extension will be documented in this file.
 
+## [1.5.0]
+
+### Added
+- New setting `enabledFilePatterns` to show status bar only for files matching specific glob patterns (e.g., `["*.md", "*.mdc"]`).
+
+## [1.4.0]
+
+### Added
+- Token highlighting feature with configurable colors.
+
 ## [1.3.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
     <h1>Live LLM Token Counter</h1>
     <img src="images/icon.png" alt="Logo" width="300" height="300"><br>
-    <a href="https://marketplace.visualstudio.com/items?itemName=bedirt.gpt-token-counter-live"><img src="https://img.shields.io/badge/VSCode-v1.4.0-blue?style=flat&logo=visualstudiocode" alt="VSCode Version"></a>
-    <a href="https://open-vsx.org/extension/bedirt/gpt-token-counter-live"><img alt="OpenVSX Version" src="https://img.shields.io/badge/OpenVSX%20-%20v1.4.0%20-%20%23bb3ec2?style=flat"></a>
+    <a href="https://marketplace.visualstudio.com/items?itemName=bedirt.gpt-token-counter-live"><img src="https://img.shields.io/badge/VSCode-v1.5.0-blue?style=flat&logo=visualstudiocode" alt="VSCode Version"></a>
+    <a href="https://open-vsx.org/extension/bedirt/gpt-token-counter-live"><img alt="OpenVSX Version" src="https://img.shields.io/badge/OpenVSX%20-%20v1.5.0%20-%20%23bb3ec2?style=flat"></a>
     <br><br>
 </div>
 
@@ -100,6 +100,10 @@ This extension contributes the following settings:
   - Default: `Token Count: {count} ({family})`
   - Supported placeholders: `{count}`, `{family}`, `{model}` (alias for family), `{provider}`
 
+- **`gpt-token-counter-live.enabledFilePatterns`**: Glob patterns for files where the status bar should be shown.
+  - Default: `[]` (empty array shows for all files)
+  - Example: `["*.md", "*.mdc"]` shows only for markdown files
+
 ### Highlighting Configuration
 Token highlight colors are stored in your VS Code global state (synced across devices if you have Settings Sync enabled). To customize them select `Configure Token Highlight Colors` option from the Command Palette.
 
@@ -110,6 +114,10 @@ Token highlight colors are stored in your VS Code global state (synced across de
 There are currently no known issues. If you encounter a problem, please report it on the [issue tracker](https://github.com/BedirT/LLM-Token-Counter-VSCode/issues).
 
 ## Release Notes
+
+### 1.5.0 - File Pattern Filtering
+
+- **New setting `enabledFilePatterns`**: Show status bar only for files matching specific glob patterns (e.g., `["*.md", "*.mdc"]`). Empty array shows for all files.
 
 ### 1.4.0 - Token Highlighting & Customization
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
     <h1>Live LLM Token Counter</h1>
     <img src="images/icon.png" alt="Logo" width="300" height="300"><br>
-    <a href="https://marketplace.visualstudio.com/items?itemName=bedirt.gpt-token-counter-live"><img src="https://img.shields.io/badge/VSCode-v1.5.0-blue?style=flat&logo=visualstudiocode" alt="VSCode Version"></a>
-    <a href="https://open-vsx.org/extension/bedirt/gpt-token-counter-live"><img alt="OpenVSX Version" src="https://img.shields.io/badge/OpenVSX%20-%20v1.5.0%20-%20%23bb3ec2?style=flat"></a>
+    <a href="https://marketplace.visualstudio.com/items?itemName=bedirt.gpt-token-counter-live"><img src="https://img.shields.io/badge/VSCode-v1.4.0-blue?style=flat&logo=visualstudiocode" alt="VSCode Version"></a>
+    <a href="https://open-vsx.org/extension/bedirt/gpt-token-counter-live"><img alt="OpenVSX Version" src="https://img.shields.io/badge/OpenVSX%20-%20v1.4.0%20-%20%23bb3ec2?style=flat"></a>
     <br><br>
 </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "gpt-token-counter-live",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gpt-token-counter-live",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",
+        "minimatch": "^9.0.0",
         "tiktoken": "^1.0.22"
       },
       "devDependencies": {
@@ -99,6 +100,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
@@ -123,6 +148,30 @@
       },
       "engines": {
         "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -254,6 +303,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -359,7 +409,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -424,14 +473,12 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -774,6 +821,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -852,6 +900,30 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/espree": {
@@ -1088,16 +1160,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
@@ -1516,16 +1578,18 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha": {
@@ -1562,16 +1626,6 @@
       },
       "engines": {
         "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
@@ -2014,6 +2068,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -2034,6 +2099,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/run-parallel": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gpt-token-counter-live",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gpt-token-counter-live",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gpt-token-counter-live",
-  "version": "1.5.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gpt-token-counter-live",
-      "version": "1.5.0",
+      "version": "1.3.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gpt-token-counter-live",
   "displayName": "Live LLM Token Counter",
   "description": "Live Token Counter for Language Models",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "publisher": "bedirt",
   "author": {
     "name": "BedirT"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gpt-token-counter-live",
   "displayName": "Live LLM Token Counter",
   "description": "Live Token Counter for Language Models",
-  "version": "1.5.0",
+  "version": "1.4.0",
   "publisher": "bedirt",
   "author": {
     "name": "BedirT"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@anthropic-ai/tokenizer": "^0.0.4",
+    "minimatch": "^9.0.0",
     "tiktoken": "^1.0.22"
   },
   "contributes": {
@@ -94,6 +95,14 @@
           "type": "string",
           "default": "Token Count: {count} ({family})",
           "markdownDescription": "Template used for the status bar text. Supported placeholders: `{count}`, `{family}`, `{provider}` (alias `{model}` for family)."
+        },
+        "gpt-token-counter-live.enabledFilePatterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Glob patterns for files where the status bar should be shown (e.g., `[\"*.md\", \"*.mdc\"]`). Empty array shows for all files."
         }
       }
     }

--- a/src/extension.js
+++ b/src/extension.js
@@ -2,6 +2,7 @@ const vscode = require('vscode');
 const { encoding_for_model, get_encoding } = require('tiktoken');
 const { countTokens, getTokenizer } = require('@anthropic-ai/tokenizer');
 const { TextDecoder } = require('util');
+const { minimatch } = require('minimatch');
 
 const utf8Decoder = new TextDecoder('utf-8');
 
@@ -129,6 +130,7 @@ let highlightColors = {
 };
 
 let statusBarTemplate = DEFAULT_STATUS_TEMPLATE;
+let enabledFilePatterns = [];
 
 function loadHighlightColors(context) {
     let evenStored = context.globalState.get(HIGHLIGHT_EVEN_KEY);
@@ -164,6 +166,34 @@ function loadHighlightColors(context) {
 function loadStatusBarConfig() {
     const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
     statusBarTemplate = sanitizeTemplateSetting(config.get('statusBarDisplayTemplate'), DEFAULT_STATUS_TEMPLATE);
+}
+
+function loadEnabledFilePatterns() {
+    const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
+    const patterns = config.get('enabledFilePatterns');
+    enabledFilePatterns = Array.isArray(patterns)
+        ? patterns.filter(p => typeof p === 'string' && p.trim()).map(p => p.trim())
+        : [];
+}
+
+function matchesEnabledFilePatterns(editor) {
+    if (!editor || !editor.document) {
+        return false;
+    }
+    // Empty patterns array means show for all files
+    if (enabledFilePatterns.length === 0) {
+        return true;
+    }
+    const filePath = editor.document.uri.fsPath;
+    const fileName = filePath.split(/[\\/]/).pop() || '';
+    // Normalize path by removing leading separators for glob pattern matching
+    // This ensures patterns like "**/docs/*.md" work correctly with absolute paths
+    const normalizedPath = filePath.replace(/^[\\/]+/, '');
+    // Match against both full path and filename for flexibility
+    return enabledFilePatterns.some(pattern => {
+        const opts = { dot: true, nocase: process.platform === 'win32' };
+        return minimatch(fileName, pattern, opts) || minimatch(normalizedPath, pattern, opts);
+    });
 }
 
 function isHighlightableEditor(editor) {
@@ -235,6 +265,7 @@ function activate(context) {
 
     loadHighlightColors(context);
     loadStatusBarConfig();
+    loadEnabledFilePatterns();
 
     const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
     statusBar.command = 'gpt-token-counter-live.changeModel';
@@ -364,7 +395,7 @@ function activate(context) {
 
     function updateHighlightStatusBar() {
         const activeEditor = vscode.window.activeTextEditor;
-        if (!activeEditor || !isHighlightableEditor(activeEditor)) {
+        if (!activeEditor || !isHighlightableEditor(activeEditor) || !matchesEnabledFilePatterns(activeEditor)) {
             highlightStatusBar.hide();
             return;
         }
@@ -532,6 +563,13 @@ function activate(context) {
             return;
         }
 
+        if (!matchesEnabledFilePatterns(editor)) {
+            statusBar.hide();
+            clearTokenHighlights(editor);
+            highlightStatusBar.hide();
+            return;
+        }
+
         const document = editor.document;
         const selection = editor.selection;
         const text = selection.isEmpty ? document.getText() : document.getText(selection);
@@ -583,6 +621,11 @@ function activate(context) {
 
                 updateTokenCount();
             }
+        }
+
+        if (event.affectsConfiguration(`${CONFIG_SECTION}.enabledFilePatterns`)) {
+            loadEnabledFilePatterns();
+            updateTokenCount();
         }
     }, null, context.subscriptions);
 
@@ -987,5 +1030,15 @@ function deactivate() {
 
 module.exports = {
     activate,
-    deactivate
+    deactivate,
+    // Exported for testing
+    _test: {
+        loadEnabledFilePatterns,
+        matchesEnabledFilePatterns,
+        setEnabledFilePatterns: (patterns) => {
+            enabledFilePatterns = Array.isArray(patterns)
+                ? patterns.filter(p => typeof p === 'string' && p.trim()).map(p => p.trim())
+                : [];
+        }
+    }
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -168,12 +168,15 @@ function loadStatusBarConfig() {
     statusBarTemplate = sanitizeTemplateSetting(config.get('statusBarDisplayTemplate'), DEFAULT_STATUS_TEMPLATE);
 }
 
-function loadEnabledFilePatterns() {
-    const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
-    const patterns = config.get('enabledFilePatterns');
-    enabledFilePatterns = Array.isArray(patterns)
+function normalizeEnabledFilePatterns(patterns) {
+    return Array.isArray(patterns)
         ? patterns.filter(p => typeof p === 'string' && p.trim()).map(p => p.trim())
         : [];
+}
+
+function loadEnabledFilePatterns() {
+    const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
+    enabledFilePatterns = normalizeEnabledFilePatterns(config.get('enabledFilePatterns'));
 }
 
 function matchesEnabledFilePatterns(editor) {
@@ -185,10 +188,11 @@ function matchesEnabledFilePatterns(editor) {
         return true;
     }
     const filePath = editor.document.uri.fsPath;
-    const fileName = filePath.split(/[\\/]/).pop() || '';
-    // Normalize path by removing leading separators for glob pattern matching
-    // This ensures patterns like "**/docs/*.md" work correctly with absolute paths
-    const normalizedPath = filePath.replace(/^[\\/]+/, '');
+    // Normalize to forward slashes, strip Windows drive letter (e.g. "C:"), then
+    // strip any leading separator so minimatch glob patterns work cross-platform
+    const unixPath = filePath.replace(/\\/g, '/');
+    const fileName = unixPath.split('/').pop() || '';
+    const normalizedPath = unixPath.replace(/^[A-Za-z]:/, '').replace(/^\/+/, '');
     // Match against both full path and filename for flexibility
     return enabledFilePatterns.some(pattern => {
         const opts = { dot: true, nocase: process.platform === 'win32' };
@@ -1036,9 +1040,7 @@ module.exports = {
         loadEnabledFilePatterns,
         matchesEnabledFilePatterns,
         setEnabledFilePatterns: (patterns) => {
-            enabledFilePatterns = Array.isArray(patterns)
-                ? patterns.filter(p => typeof p === 'string' && p.trim()).map(p => p.trim())
-                : [];
+            enabledFilePatterns = normalizeEnabledFilePatterns(patterns);
         }
     }
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -179,25 +179,27 @@ function loadEnabledFilePatterns() {
     enabledFilePatterns = normalizeEnabledFilePatterns(config.get('enabledFilePatterns'));
 }
 
+function matchesFilePatterns(relativePath, patterns) {
+    if (!Array.isArray(patterns) || patterns.length === 0) {
+        return true;
+    }
+    if (typeof relativePath !== 'string') {
+        return false;
+    }
+    const unixPath = relativePath.replace(/\\/g, '/');
+    const fileName = unixPath.split('/').pop() || '';
+    return patterns.some(pattern => {
+        const opts = { dot: true, nocase: process.platform === 'win32' };
+        return minimatch(fileName, pattern, opts) || minimatch(unixPath, pattern, opts);
+    });
+}
+
 function matchesEnabledFilePatterns(editor) {
     if (!editor || !editor.document) {
         return false;
     }
-    // Empty patterns array means show for all files
-    if (enabledFilePatterns.length === 0) {
-        return true;
-    }
-    const filePath = editor.document.uri.fsPath;
-    // Normalize to forward slashes, strip Windows drive letter (e.g. "C:"), then
-    // strip any leading separator so minimatch glob patterns work cross-platform
-    const unixPath = filePath.replace(/\\/g, '/');
-    const fileName = unixPath.split('/').pop() || '';
-    const normalizedPath = unixPath.replace(/^[A-Za-z]:/, '').replace(/^\/+/, '');
-    // Match against both full path and filename for flexibility
-    return enabledFilePatterns.some(pattern => {
-        const opts = { dot: true, nocase: process.platform === 'win32' };
-        return minimatch(fileName, pattern, opts) || minimatch(normalizedPath, pattern, opts);
-    });
+    const relativePath = vscode.workspace.asRelativePath(editor.document.uri, false);
+    return matchesFilePatterns(relativePath, enabledFilePatterns);
 }
 
 function isHighlightableEditor(editor) {
@@ -1035,10 +1037,11 @@ function deactivate() {
 module.exports = {
     activate,
     deactivate,
-    // Exported for testing
     _test: {
         loadEnabledFilePatterns,
         matchesEnabledFilePatterns,
+        matchesFilePatterns,
+        normalizeEnabledFilePatterns,
         setEnabledFilePatterns: (patterns) => {
             enabledFilePatterns = normalizeEnabledFilePatterns(patterns);
         }

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -13,111 +13,81 @@ suite('Extension Test Suite', () => {
 });
 
 suite('File Pattern Matching', () => {
-	const { setEnabledFilePatterns, matchesEnabledFilePatterns } = extension._test;
+	const {
+		matchesFilePatterns,
+		matchesEnabledFilePatterns,
+		normalizeEnabledFilePatterns,
+		setEnabledFilePatterns
+	} = extension._test;
 
-	/**
-	 * Create a mock editor object for testing
-	 * @param {string} filePath - The file path to use
-	 * @returns {object} Mock editor object
-	 */
-	function createMockEditor(filePath) {
-		return {
-			document: {
-				uri: {
-					fsPath: filePath
-				}
-			}
-		};
-	}
-
-	test('Empty patterns array should match all files', () => {
-		setEnabledFilePatterns([]);
-
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.js')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.md')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.mdc')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.txt')), true);
+	test('Empty patterns matches any path', () => {
+		assert.strictEqual(matchesFilePatterns('docs/file.md', []), true);
+		assert.strictEqual(matchesFilePatterns('src/main.js', []), true);
+		assert.strictEqual(matchesFilePatterns('', []), true);
 	});
 
-	test('Should match *.md pattern', () => {
+	test('Filename-only globs match by basename', () => {
+		assert.strictEqual(matchesFilePatterns('README.md', ['*.md']), true);
+		assert.strictEqual(matchesFilePatterns('docs/file.md', ['*.md']), true);
+		assert.strictEqual(matchesFilePatterns('deeply/nested/path/file.md', ['*.md']), true);
+		assert.strictEqual(matchesFilePatterns('src/main.js', ['*.md']), false);
+		assert.strictEqual(matchesFilePatterns('docs/file.mdc', ['*.md']), false);
+	});
+
+	test('Multiple patterns match with OR semantics', () => {
+		const patterns = ['*.md', '*.mdc'];
+		assert.strictEqual(matchesFilePatterns('README.md', patterns), true);
+		assert.strictEqual(matchesFilePatterns('rules.mdc', patterns), true);
+		assert.strictEqual(matchesFilePatterns('main.js', patterns), false);
+	});
+
+	test('Workspace-relative directory patterns', () => {
+		// Users writing `docs/*.md` expect it to match files directly in the workspace's docs/ folder.
+		assert.strictEqual(matchesFilePatterns('docs/file.md', ['docs/*.md']), true);
+		assert.strictEqual(matchesFilePatterns('nested/docs/file.md', ['docs/*.md']), false);
+		// Explicit `**` still works for any-depth matching.
+		assert.strictEqual(matchesFilePatterns('nested/docs/file.md', ['**/docs/*.md']), true);
+		assert.strictEqual(matchesFilePatterns('docs/file.md', ['**/docs/*.md']), true);
+	});
+
+	test('Dotfiles match via dot:true option', () => {
+		assert.strictEqual(matchesFilePatterns('.hidden.md', ['*.md']), true);
+		assert.strictEqual(matchesFilePatterns('.config/settings.md', ['**/*.md']), true);
+	});
+
+	test('Windows backslash separators are normalized', () => {
+		assert.strictEqual(matchesFilePatterns('docs\\file.md', ['docs/*.md']), true);
+		assert.strictEqual(matchesFilePatterns('project\\docs\\readme.md', ['**/docs/*.md']), true);
+		assert.strictEqual(matchesFilePatterns('project\\src\\main.js', ['**/docs/*.md']), false);
+	});
+
+	test('Non-string path returns false when patterns are non-empty', () => {
+		assert.strictEqual(matchesFilePatterns(null, ['*.md']), false);
+		assert.strictEqual(matchesFilePatterns(undefined, ['*.md']), false);
+		assert.strictEqual(matchesFilePatterns(42, ['*.md']), false);
+	});
+
+	test('matchesEnabledFilePatterns guards null/undefined editors', () => {
 		setEnabledFilePatterns(['*.md']);
-
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.md')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/README.md')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.js')), false);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.mdc')), false);
-	});
-
-	test('Should match *.mdc pattern', () => {
-		setEnabledFilePatterns(['*.mdc']);
-
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.mdc')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/rules.mdc')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.md')), false);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.js')), false);
-	});
-
-	test('Should match multiple patterns (*.md, *.mdc)', () => {
-		setEnabledFilePatterns(['*.md', '*.mdc']);
-
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.md')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.mdc')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/README.md')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/rules.mdc')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.js')), false);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.txt')), false);
-	});
-
-	test('Should handle dotfiles when pattern includes dot', () => {
-		setEnabledFilePatterns(['*.md']);
-
-		// Files starting with dot should still match if extension matches
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/.hidden.md')), true);
-	});
-
-	test('Should return false for null/undefined editor', () => {
-		setEnabledFilePatterns(['*.md']);
-
 		assert.strictEqual(matchesEnabledFilePatterns(null), false);
 		assert.strictEqual(matchesEnabledFilePatterns(undefined), false);
 		assert.strictEqual(matchesEnabledFilePatterns({}), false);
 		assert.strictEqual(matchesEnabledFilePatterns({ document: null }), false);
 	});
 
-	test('Should match patterns with path separators', () => {
-		setEnabledFilePatterns(['**/*.md']);
-
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.md')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/deeply/nested/path/file.md')), true);
+	test('normalizeEnabledFilePatterns trims and drops non-strings', () => {
+		assert.deepStrictEqual(
+			normalizeEnabledFilePatterns([' *.md ', '  *.mdc  ']),
+			['*.md', '*.mdc']
+		);
+		assert.deepStrictEqual(
+			normalizeEnabledFilePatterns(['*.md', '', '   ', null, 42, '*.js']),
+			['*.md', '*.js']
+		);
+		assert.deepStrictEqual(normalizeEnabledFilePatterns(null), []);
+		assert.deepStrictEqual(normalizeEnabledFilePatterns('not-an-array'), []);
 	});
 
-	test('Should match specific directory patterns', () => {
-		setEnabledFilePatterns(['**/docs/*.md']);
-
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/project/docs/readme.md')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/docs/guide.md')), true);
-	});
-
-	test('Should trim whitespace from patterns', () => {
-		// This test verifies that patterns with leading/trailing whitespace are trimmed
-		// If patterns aren't trimmed, " *.md " would fail to match "file.md"
-		setEnabledFilePatterns([' *.md ', '  *.mdc  ']);
-
-		// These should match because patterns should be trimmed to "*.md" and "*.mdc"
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.md')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.mdc')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.js')), false);
-	});
-
-	test('Should match Windows-style paths with forward-slash globs', () => {
-		setEnabledFilePatterns(['**/docs/*.md']);
-
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('C:\\project\\docs\\readme.md')), true);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('C:\\project\\src\\main.js')), false);
-		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('D:\\nested\\docs\\guide.md')), true);
-	});
-
-	// Cleanup after tests
 	suiteTeardown(() => {
 		setEnabledFilePatterns([]);
 	});

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -1,9 +1,7 @@
 const assert = require('assert');
-
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
 const vscode = require('vscode');
-// const myExtension = require('../extension');
+
+const extension = require('../../src/extension');
 
 suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
@@ -11,5 +9,108 @@ suite('Extension Test Suite', () => {
 	test('Sample test', () => {
 		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
 		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+	});
+});
+
+suite('File Pattern Matching', () => {
+	const { setEnabledFilePatterns, matchesEnabledFilePatterns } = extension._test;
+
+	/**
+	 * Create a mock editor object for testing
+	 * @param {string} filePath - The file path to use
+	 * @returns {object} Mock editor object
+	 */
+	function createMockEditor(filePath) {
+		return {
+			document: {
+				uri: {
+					fsPath: filePath
+				}
+			}
+		};
+	}
+
+	test('Empty patterns array should match all files', () => {
+		setEnabledFilePatterns([]);
+
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.js')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.md')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.mdc')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.txt')), true);
+	});
+
+	test('Should match *.md pattern', () => {
+		setEnabledFilePatterns(['*.md']);
+
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.md')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/README.md')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.js')), false);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.mdc')), false);
+	});
+
+	test('Should match *.mdc pattern', () => {
+		setEnabledFilePatterns(['*.mdc']);
+
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.mdc')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/rules.mdc')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.md')), false);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.js')), false);
+	});
+
+	test('Should match multiple patterns (*.md, *.mdc)', () => {
+		setEnabledFilePatterns(['*.md', '*.mdc']);
+
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.md')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.mdc')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/README.md')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/rules.mdc')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.js')), false);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.txt')), false);
+	});
+
+	test('Should handle dotfiles when pattern includes dot', () => {
+		setEnabledFilePatterns(['*.md']);
+
+		// Files starting with dot should still match if extension matches
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/.hidden.md')), true);
+	});
+
+	test('Should return false for null/undefined editor', () => {
+		setEnabledFilePatterns(['*.md']);
+
+		assert.strictEqual(matchesEnabledFilePatterns(null), false);
+		assert.strictEqual(matchesEnabledFilePatterns(undefined), false);
+		assert.strictEqual(matchesEnabledFilePatterns({}), false);
+		assert.strictEqual(matchesEnabledFilePatterns({ document: null }), false);
+	});
+
+	test('Should match patterns with path separators', () => {
+		setEnabledFilePatterns(['**/*.md']);
+
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.md')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/deeply/nested/path/file.md')), true);
+	});
+
+	test('Should match specific directory patterns', () => {
+		setEnabledFilePatterns(['**/docs/*.md']);
+
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/project/docs/readme.md')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/docs/guide.md')), true);
+	});
+
+	test('Should trim whitespace from patterns', () => {
+		// This test verifies that patterns with leading/trailing whitespace are trimmed
+		// If patterns aren't trimmed, " *.md " would fail to match "file.md"
+		setEnabledFilePatterns([' *.md ', '  *.mdc  ']);
+
+		// These should match because patterns should be trimmed to "*.md" and "*.mdc"
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.md')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.mdc')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.js')), false);
+	});
+
+	// Cleanup after tests
+	suiteTeardown(() => {
+		setEnabledFilePatterns([]);
 	});
 });

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -109,6 +109,14 @@ suite('File Pattern Matching', () => {
 		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('/path/to/file.js')), false);
 	});
 
+	test('Should match Windows-style paths with forward-slash globs', () => {
+		setEnabledFilePatterns(['**/docs/*.md']);
+
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('C:\\project\\docs\\readme.md')), true);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('C:\\project\\src\\main.js')), false);
+		assert.strictEqual(matchesEnabledFilePatterns(createMockEditor('D:\\nested\\docs\\guide.md')), true);
+	});
+
 	// Cleanup after tests
 	suiteTeardown(() => {
 		setEnabledFilePatterns([]);


### PR DESCRIPTION
Add `enabledFilePatterns` setting to show token counter only for files matching specific glob patterns.

Coded with Claude Opus 4.5