### PR TITLE
Fix token highlighting for UTF-8 and Claude normalization

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -444,6 +444,13 @@ function activate(context) {
         const sourceBytes = Buffer.from(renderedText, 'utf8');
         const boundaries = buildUtf8BoundaryMap(renderedText);
         const normalizationOffsetMap = tokenizationResult.normalizationOffsetMap || null;
+
+        if (tokenizationResult.normalizationChanged && !normalizationOffsetMap) {
+            clearTokenHighlights(editor);
+            console.warn('[gpt-token-counter-live] Token highlighting skipped because normalization offsets could not be mapped to the original document.');
+            return;
+        }
+
         let byteCursor = 0;
         let hasMismatch = false;
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,9 +1,6 @@
 const vscode = require('vscode');
 const { encoding_for_model, get_encoding } = require('tiktoken');
 const { countTokens, getTokenizer } = require('@anthropic-ai/tokenizer');
-const { TextDecoder } = require('util');
-
-const utf8Decoder = new TextDecoder('utf-8');
 
 const CONFIG_SECTION = 'gpt-token-counter-live';
 const DEFAULT_EVEN_COLOR = '#B8D4FF';
@@ -121,6 +118,133 @@ function sanitizeProviderSetting(value) {
         }
     }
     return 'openai';
+}
+
+function buildUtf8BoundaryMap(text) {
+    const boundaries = new Map();
+    boundaries.set(0, 0);
+
+    let utf16Offset = 0;
+    let byteOffset = 0;
+
+    while (utf16Offset < text.length) {
+        const codePoint = text.codePointAt(utf16Offset);
+        const char = String.fromCodePoint(codePoint);
+        const utf16Width = char.length;
+        const byteWidth = Buffer.byteLength(char, 'utf8');
+
+        utf16Offset += utf16Width;
+        byteOffset += byteWidth;
+        boundaries.set(byteOffset, utf16Offset);
+    }
+
+    return boundaries;
+}
+
+function resolveUtf16Offset(boundaries, byteOffset, maxByteOffset, direction) {
+    if (boundaries.has(byteOffset)) {
+        return boundaries.get(byteOffset);
+    }
+
+    if (direction === 'backward') {
+        for (let cursor = byteOffset; cursor >= 0; cursor--) {
+            if (boundaries.has(cursor)) {
+                return boundaries.get(cursor);
+            }
+        }
+    } else {
+        for (let cursor = byteOffset; cursor <= maxByteOffset; cursor++) {
+            if (boundaries.has(cursor)) {
+                return boundaries.get(cursor);
+            }
+        }
+    }
+
+    return null;
+}
+
+function iterateGraphemeSegments(text) {
+    if (typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function') {
+        const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+        return Array.from(segmenter.segment(text), ({ segment, index }) => ({
+            segment,
+            index
+        }));
+    }
+
+    const segments = [];
+    let index = 0;
+    while (index < text.length) {
+        const codePoint = text.codePointAt(index);
+        const segment = String.fromCodePoint(codePoint);
+        segments.push({ segment, index });
+        index += segment.length;
+    }
+    return segments;
+}
+
+function buildNormalizationOffsetMap(text) {
+    const normalizedText = text.normalize('NFKC');
+    const backward = new Array(normalizedText.length + 1);
+    const forward = new Array(normalizedText.length + 1);
+    const normalizedChunks = [];
+    let normalizedOffset = 0;
+
+    for (const { segment, index } of iterateGraphemeSegments(text)) {
+        const normalizedSegment = segment.normalize('NFKC');
+        const originalStart = index;
+        const originalEnd = index + segment.length;
+        const start = normalizedOffset;
+        const end = start + normalizedSegment.length;
+
+        normalizedChunks.push(normalizedSegment);
+
+        if (start === end) {
+            backward[start] = originalEnd;
+            forward[start] = originalEnd;
+        } else {
+            backward[start] = originalStart;
+            forward[start] = originalStart;
+
+            for (let cursor = start + 1; cursor < end; cursor++) {
+                backward[cursor] = originalStart;
+                forward[cursor] = originalEnd;
+            }
+
+            backward[end] = originalEnd;
+            forward[end] = originalEnd;
+        }
+
+        normalizedOffset = end;
+    }
+
+    const rebuiltNormalizedText = normalizedChunks.join('');
+    if (rebuiltNormalizedText !== normalizedText) {
+        return null;
+    }
+
+    backward[0] = 0;
+    forward[0] = 0;
+    backward[normalizedText.length] = text.length;
+    forward[normalizedText.length] = text.length;
+
+    return {
+        normalizedText,
+        backward,
+        forward
+    };
+}
+
+function resolveOriginalOffsetFromNormalized(offsetMap, normalizedOffset, direction) {
+    if (!offsetMap || normalizedOffset < 0 || normalizedOffset >= offsetMap.backward.length) {
+        return null;
+    }
+
+    if (direction === 'backward') {
+        return offsetMap.backward[normalizedOffset];
+    }
+
+    return offsetMap.forward[normalizedOffset];
 }
 
 let highlightColors = {
@@ -312,54 +436,91 @@ function activate(context) {
             return;
         }
 
-        if (tokenizationResult.normalizationChanged) {
-            clearTokenHighlights(editor);
-            return;
-        }
-
         const evenRanges = [];
         const oddRanges = [];
         const tokens = tokenizationResult.tokens;
         const document = editor.document;
-        let searchIndex = 0;
+        const renderedText = tokenizationResult.processedText || sourceText;
+        const sourceBytes = Buffer.from(renderedText, 'utf8');
+        const boundaries = buildUtf8BoundaryMap(renderedText);
+        const normalizationOffsetMap = tokenizationResult.normalizationOffsetMap || null;
+        let byteCursor = 0;
+        let hasMismatch = false;
 
         for (let i = 0; i < tokens.length; i++) {
             const tokenId = tokens[i];
-            let tokenString;
+            let tokenBytes;
 
             try {
-                const bytes = tokenizerState.encoder.decode_single_token_bytes(tokenId);
-                tokenString = utf8Decoder.decode(bytes);
+                tokenBytes = tokenizerState.encoder.decode_single_token_bytes(tokenId);
             } catch (error) {
-                clearTokenHighlights(editor);
-                return;
+                hasMismatch = true;
+                break;
             }
 
-            if (!tokenString.length) {
+            if (!tokenBytes.length) {
                 continue;
             }
 
-            const foundIndex = sourceText.indexOf(tokenString, searchIndex);
-            if (foundIndex === -1) {
-                clearTokenHighlights(editor);
-                return;
+            const startByte = byteCursor;
+            const endByte = startByte + tokenBytes.length;
+
+            if (endByte > sourceBytes.length) {
+                hasMismatch = true;
+                break;
             }
 
-            const startOffset = baseOffset + foundIndex;
-            const endOffset = startOffset + tokenString.length;
+            const expectedBytes = sourceBytes.subarray(startByte, endByte);
+            if (!Buffer.from(tokenBytes).equals(expectedBytes)) {
+                hasMismatch = true;
+                break;
+            }
+
+            const startUtf16 = resolveUtf16Offset(boundaries, startByte, sourceBytes.length, 'backward');
+            const endUtf16 = resolveUtf16Offset(boundaries, endByte, sourceBytes.length, 'forward');
+
+            if (startUtf16 === null || endUtf16 === null) {
+                hasMismatch = true;
+                break;
+            }
+
+            const mappedStart = normalizationOffsetMap
+                ? resolveOriginalOffsetFromNormalized(normalizationOffsetMap, startUtf16, 'backward')
+                : startUtf16;
+            const mappedEnd = normalizationOffsetMap
+                ? resolveOriginalOffsetFromNormalized(normalizationOffsetMap, endUtf16, 'forward')
+                : endUtf16;
+
+            if (mappedStart === null || mappedEnd === null) {
+                hasMismatch = true;
+                break;
+            }
+
+            const startOffset = baseOffset + mappedStart;
+            const endOffset = baseOffset + mappedEnd;
             const range = new vscode.Range(document.positionAt(startOffset), document.positionAt(endOffset));
 
-            if (i % 2 === 0) {
-                evenRanges.push(range);
-            } else {
-                oddRanges.push(range);
+            if (!range.isEmpty) {
+                if (i % 2 === 0) {
+                    evenRanges.push(range);
+                } else {
+                    oddRanges.push(range);
+                }
             }
 
-            searchIndex = foundIndex + tokenString.length;
+            byteCursor = endByte;
+        }
+
+        if (byteCursor !== sourceBytes.length) {
+            hasMismatch = true;
         }
 
         editor.setDecorations(tokenDecorations.even, evenRanges);
         editor.setDecorations(tokenDecorations.odd, oddRanges);
+
+        if (hasMismatch) {
+            console.warn('[gpt-token-counter-live] Partial token highlight render due to unsupported UTF-8 token boundaries.');
+        }
     }
 
     function updateHighlightStatusBar() {
@@ -497,11 +658,16 @@ function activate(context) {
             const processedText = tokenizerState.requiresNormalization ? text.normalize('NFKC') : text;
             try {
                 const encoded = tokenizerState.encoder.encode(processedText, 'all');
+                const normalizationOffsetMap = tokenizerState.requiresNormalization && processedText !== text
+                    ? buildNormalizationOffsetMap(text)
+                    : null;
                 return {
                     tokenCount: encoded.length,
                     tokenizationResult: {
                         tokens: encoded,
-                        normalizationChanged: tokenizerState.requiresNormalization && processedText !== text
+                        normalizationChanged: tokenizerState.requiresNormalization && processedText !== text,
+                        processedText,
+                        normalizationOffsetMap
                     }
                 };
             } catch (error) {
@@ -987,5 +1153,11 @@ function deactivate() {
 
 module.exports = {
     activate,
-    deactivate
-}
+    deactivate,
+    __internal: {
+        buildUtf8BoundaryMap,
+        resolveUtf16Offset,
+        buildNormalizationOffsetMap,
+        resolveOriginalOffsetFromNormalized
+    }
+};

--- a/src/extension.js
+++ b/src/extension.js
@@ -164,23 +164,15 @@ function resolveUtf16Offset(boundaries, byteOffset, maxByteOffset, direction) {
 }
 
 function iterateGraphemeSegments(text) {
-    if (typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function') {
-        const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
-        return Array.from(segmenter.segment(text), ({ segment, index }) => ({
-            segment,
-            index
-        }));
+    if (typeof Intl === 'undefined' || typeof Intl.Segmenter !== 'function') {
+        throw new Error('Intl.Segmenter is required for token normalization mapping.');
     }
 
-    const segments = [];
-    let index = 0;
-    while (index < text.length) {
-        const codePoint = text.codePointAt(index);
-        const segment = String.fromCodePoint(codePoint);
-        segments.push({ segment, index });
-        index += segment.length;
-    }
-    return segments;
+    const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+    return Array.from(segmenter.segment(text), ({ segment, index }) => ({
+        segment,
+        index
+    }));
 }
 
 function buildNormalizationOffsetMap(text) {
@@ -218,6 +210,7 @@ function buildNormalizationOffsetMap(text) {
         normalizedOffset = end;
     }
 
+    // Whole-text NFKC can merge across grapheme boundaries, so reject per-segment maps that do not reassemble exactly.
     const rebuiltNormalizedText = normalizedChunks.join('');
     if (rebuiltNormalizedText !== normalizedText) {
         return null;
@@ -522,12 +515,14 @@ function activate(context) {
             hasMismatch = true;
         }
 
+        if (hasMismatch) {
+            clearTokenHighlights(editor);
+            console.warn('[gpt-token-counter-live] Partial token highlight render due to unsupported UTF-8 token boundaries.');
+            return;
+        }
+
         editor.setDecorations(tokenDecorations.even, evenRanges);
         editor.setDecorations(tokenDecorations.odd, oddRanges);
-
-        if (hasMismatch) {
-            console.warn('[gpt-token-counter-live] Partial token highlight render due to unsupported UTF-8 token boundaries.');
-        }
     }
 
     function updateHighlightStatusBar() {

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -63,4 +63,8 @@ suite('Extension Test Suite', () => {
 		assert.strictEqual(extension.__internal.resolveOriginalOffsetFromNormalized(map, 1, 'forward'), 1);
 		assert.strictEqual(extension.__internal.resolveOriginalOffsetFromNormalized(map, 2, 'forward'), 2);
 	});
+
+	test('normalization offset map returns null when NFKC merges across grapheme boundaries', () => {
+		assert.strictEqual(extension.__internal.buildNormalizationOffsetMap('\uFFB5\uFFCC'), null);
+	});
 });

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 const vscode = require('vscode');
-// const myExtension = require('../extension');
+const extension = require('../../src/extension');
 
 suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
@@ -11,5 +11,56 @@ suite('Extension Test Suite', () => {
 	test('Sample test', () => {
 		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
 		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+	});
+
+	test('UTF-8 boundary map includes multi-byte character boundaries', () => {
+		const map = extension.__internal.buildUtf8BoundaryMap('A❌B');
+		assert.strictEqual(map.get(0), 0);
+		assert.strictEqual(map.get(1), 1);
+		assert.strictEqual(map.get(4), 2);
+		assert.strictEqual(map.get(5), 3);
+	});
+
+	test('resolveUtf16Offset snaps to nearest valid boundary', () => {
+		const source = 'A❌B';
+		const map = extension.__internal.buildUtf8BoundaryMap(source);
+
+		const totalBytes = Buffer.byteLength(source, 'utf8');
+
+		assert.strictEqual(extension.__internal.resolveUtf16Offset(map, 2, totalBytes, 'backward'), 1);
+		assert.strictEqual(extension.__internal.resolveUtf16Offset(map, 2, totalBytes, 'forward'), 2);
+	});
+
+	test('normalization offset map preserves full-width character spans', () => {
+		const map = extension.__internal.buildNormalizationOffsetMap('ＡB');
+		assert.strictEqual(map.normalizedText, 'AB');
+		assert.strictEqual(extension.__internal.resolveOriginalOffsetFromNormalized(map, 0, 'backward'), 0);
+		assert.strictEqual(extension.__internal.resolveOriginalOffsetFromNormalized(map, 1, 'forward'), 1);
+		assert.strictEqual(extension.__internal.resolveOriginalOffsetFromNormalized(map, 2, 'forward'), 2);
+	});
+
+	test('normalization offset map expands combined characters back to original span', () => {
+		const map = extension.__internal.buildNormalizationOffsetMap('e\u0301');
+		assert.strictEqual(map.normalizedText, 'é');
+		assert.strictEqual(extension.__internal.resolveOriginalOffsetFromNormalized(map, 0, 'backward'), 0);
+		assert.strictEqual(extension.__internal.resolveOriginalOffsetFromNormalized(map, 1, 'forward'), 2);
+	});
+
+	test('normalization offset map snaps interior expanded offsets to one original grapheme', () => {
+		const map = extension.__internal.buildNormalizationOffsetMap('ﬃ');
+		assert.strictEqual(map.normalizedText, 'ffi');
+		assert.strictEqual(extension.__internal.resolveOriginalOffsetFromNormalized(map, 1, 'backward'), 0);
+		assert.strictEqual(extension.__internal.resolveOriginalOffsetFromNormalized(map, 1, 'forward'), 1);
+		assert.strictEqual(extension.__internal.resolveOriginalOffsetFromNormalized(map, 2, 'backward'), 0);
+		assert.strictEqual(extension.__internal.resolveOriginalOffsetFromNormalized(map, 2, 'forward'), 1);
+	});
+
+	test('normalization offset map preserves full-width parentheses spans', () => {
+		const map = extension.__internal.buildNormalizationOffsetMap('（）');
+		assert.strictEqual(map.normalizedText, '()');
+		assert.strictEqual(extension.__internal.resolveOriginalOffsetFromNormalized(map, 0, 'backward'), 0);
+		assert.strictEqual(extension.__internal.resolveOriginalOffsetFromNormalized(map, 1, 'backward'), 1);
+		assert.strictEqual(extension.__internal.resolveOriginalOffsetFromNormalized(map, 1, 'forward'), 1);
+		assert.strictEqual(extension.__internal.resolveOriginalOffsetFromNormalized(map, 2, 'forward'), 2);
 	});
 });

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -67,4 +67,17 @@ suite('Extension Test Suite', () => {
 	test('normalization offset map returns null when NFKC merges across grapheme boundaries', () => {
 		assert.strictEqual(extension.__internal.buildNormalizationOffsetMap('\uFFB5\uFFCC'), null);
 	});
+
+	test('iterateGraphemeSegments requires Intl.Segmenter support', () => {
+		const originalSegmenter = Intl.Segmenter;
+		try {
+			Intl.Segmenter = undefined;
+			assert.throws(
+				() => extension.__internal.buildNormalizationOffsetMap('test'),
+				/Intl\.Segmenter is required/
+			);
+		} finally {
+			Intl.Segmenter = originalSegmenter;
+		}
+	});
 });


### PR DESCRIPTION
## Summary

- switch token highlight range reconstruction from string matching to UTF-8 byte boundary tracking
- add Claude normalization offset handling for full-width punctuation such as `（）`
- add regression tests for UTF-8 boundaries and normalization offset mapping

## Repro

Before this change, token highlighting could break on multibyte characters.
A simple repro was:

```txt
A ❌ B
```

With token highlighting enabled on GPT or Claude, the highlight ranges around `❌` could become misaligned.

## Testing

- `npm test`
- manual verification in VS Code with GPT and Claude highlighting