### PR TITLE
feat: HuggingFace tokenizer provider with live highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .vscode-test/
 *.vsix
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to the "gpt-token-counter" extension will be documented in t
 ## [1.5.0]
 
 ### Added
+- HuggingFace tokenizer family: load any `tokenizer.json` from the Hub (first launch fetches + caches) or a local file.
+  - New settings: `huggingfaceModelId` and `huggingfaceTokenizerPath`.
+  - Byte-level BPE tokenizers (Qwen, Llama, Mistral, etc.) support highlighting via a decode-based offset reconstruction; SentencePiece tokenizers that transform whitespace still count tokens but skip highlights.
+  - `huggingface` added to the `defaultModelFamily` enum and to the Change Model Family quick pick.
 - New setting `enabledFilePatterns` to show status bar only for files matching specific glob patterns (e.g., `["*.md", "*.mdc"]`).
+
+### Fixed
+- Token highlighting no longer misaligns around multi-byte UTF-8 characters (emoji, CJK). The highlight renderer switched from matching decoded token strings to matching raw UTF-8 bytes against the source, so a token that spans or splits a multi-byte character still lands on the right boundary.
+- Claude token highlighting now works on documents containing characters that are rewritten by NFKC normalization (e.g., full-width `（）` becoming ASCII `()`). A per-grapheme offset map reprojects token ranges from the normalized tokenization back onto the original text.
 
 ## [1.3.0]
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <div align="center">
     <h1>Live LLM Token Counter</h1>
     <img src="images/icon.png" alt="Logo" width="300" height="300"><br>
-    <a href="https://marketplace.visualstudio.com/items?itemName=bedirt.gpt-token-counter-live"><img src="https://img.shields.io/badge/VSCode-v1.4.0-blue?style=flat&logo=visualstudiocode" alt="VSCode Version"></a>
-    <a href="https://open-vsx.org/extension/bedirt/gpt-token-counter-live"><img alt="OpenVSX Version" src="https://img.shields.io/badge/OpenVSX%20-%20v1.4.0%20-%20%23bb3ec2?style=flat"></a>
+    <a href="https://marketplace.visualstudio.com/items?itemName=bedirt.gpt-token-counter-live"><img src="https://img.shields.io/badge/VSCode-v1.5.0-blue?style=flat&logo=visualstudiocode" alt="VSCode Version"></a>
+    <a href="https://open-vsx.org/extension/bedirt/gpt-token-counter-live"><img alt="OpenVSX Version" src="https://img.shields.io/badge/OpenVSX%20-%20v1.5.0%20-%20%23bb3ec2?style=flat"></a>
     <br><br>
 </div>
 
-The "gpt-token-counter-live" is a Visual Studio Code extension that displays the token count of selected text or the entire open document in the status bar. The token count is determined per model family using: [GPT via tiktoken](https://www.npmjs.com/package/tiktoken), [Claude via Anthropic's tokenizer](https://github.com/anthropics/anthropic-tokenizer-typescript), and Gemini via a local approximation.
+The "gpt-token-counter-live" is a Visual Studio Code extension that displays the token count of selected text or the entire open document in the status bar. The token count is determined per model family using: [GPT via tiktoken](https://www.npmjs.com/package/tiktoken), [Claude via Anthropic's tokenizer](https://github.com/anthropics/anthropic-tokenizer-typescript), Gemini via a local approximation, and any HuggingFace tokenizer via [@huggingface/tokenizers](https://www.npmjs.com/package/@huggingface/tokenizers) (Qwen, Llama, Mistral, etc.).
 
-**NEW in v1.4.0:** Now with **visual token highlighting** overlays! See exactly where token boundaries are as you type, with customizable colors and smart text contrast.
+**NEW in v1.5.0:** Count and highlight tokens for **any HuggingFace tokenizer** (Qwen, Llama, Mistral, and more), loaded from the Hub or a local `tokenizer.json`. Plus **file pattern filtering** to scope the counter to specific file types.
 
 This tool is built to get a speedy token counting result right on VS Code while you are working on prompting files. I personally needed a lot while working on many LLM projects, so I decided to make one for myself. I hope this helps you too!
 
@@ -31,9 +31,10 @@ Click the status bar to **switch between model families**: GPT (OpenAI), Claude 
 - **GPT (OpenAI):** Uses tiktoken `encoding_for_model('gpt-5')` with fallbacks to `o200k_base` → `cl100k_base` for accurate token counting across all GPT models.
 - **Claude (Anthropic):** Uses Anthropic's official tokenizer for precise token boundaries with full highlighting support.
 - **Gemini (Google AI):** Approximates tokens using GPT encodings or ~4 chars/token fallback (highlighting not available).
+- **HuggingFace:** Loads a `tokenizer.json` from the Hub (or a local file) and reuses it for live counts. Byte-level BPE tokenizers (Qwen, Llama, Mistral, etc.) support highlighting; SentencePiece tokenizers that alter whitespace fall back to counting only.
 
 ### Visual Token Highlighting
-**See your tokens in real-time** with alternating color bands that show exactly where each token begins and ends. Available for GPT and Claude models.
+**See your tokens in real-time** with alternating color bands that show exactly where each token begins and ends. Available for GPT, Claude, and HuggingFace byte-level BPE tokenizers (Qwen, Llama, Mistral, etc.).
 
 <div align="center">
     <img src="images/highlight_on_off.gif" alt="Token highlighting toggle" width="800">
@@ -93,7 +94,7 @@ This extension contributes the following settings:
 
 ### Model & Display Settings
 - **`gpt-token-counter-live.defaultModelFamily`**: Choose which model family activates by default when you open VS Code.
-  - Options: `openai`, `anthropic`, or `gemini`
+  - Options: `openai`, `anthropic`, `gemini`, or `huggingface`
   - Default: `openai`
 
 - **`gpt-token-counter-live.statusBarDisplayTemplate`**: Customize how token information appears in the status bar.
@@ -103,6 +104,20 @@ This extension contributes the following settings:
 - **`gpt-token-counter-live.enabledFilePatterns`**: Glob patterns for files where the status bar should be shown.
   - Default: `[]` (empty array shows for all files)
   - Example: `["*.md", "*.mdc"]` shows only for markdown files
+
+### HuggingFace Tokenizers
+
+Select `HuggingFace (huggingface)` in the model family picker, then point the extension at a tokenizer with either of the settings below. The first load fetches `tokenizer.json` from the Hub and caches it under the extension's global storage directory, so subsequent launches are offline-friendly.
+
+- **`gpt-token-counter-live.huggingfaceModelId`**: HuggingFace repo ID (e.g. `Qwen/Qwen2.5-7B-Instruct`, `meta-llama/Llama-3-8B`, `mistralai/Mistral-7B-Instruct-v0.3`). The extension fetches `https://huggingface.co/{id}/resolve/main/tokenizer.json` plus `tokenizer_config.json` and caches them on disk.
+- **`gpt-token-counter-live.huggingfaceTokenizerPath`**: Absolute path to a local `tokenizer.json` file. When set, it overrides `huggingfaceModelId`. A sibling `tokenizer_config.json` will be picked up automatically if present.
+
+**What works and what doesn't:**
+
+- Byte-level BPE tokenizers (Qwen, Llama, Mistral, most GPT-style tokenizers on the Hub) give **precise token counts and highlighting**.
+- SentencePiece / Unigram tokenizers that strip or transform whitespace (T5, some BERT variants) still give precise counts, but highlighting is automatically disabled. Decoding an id sequence back to text doesn't produce an identical string, so offsets can't be attributed reliably. You'll see token counts but no color overlays.
+- **Gated or private repositories** cannot be fetched without auth. The first load will surface the raw HTTP status in a VS Code error notification (typically `401` or `403`); download `tokenizer.json` manually and point `huggingfaceTokenizerPath` at it.
+- **Missing repositories / offline first-load** show the same error notification and fall back to a rough `~4 chars/token` approximation until the tokenizer resolves.
 
 ### Highlighting Configuration
 Token highlight colors are stored in your VS Code global state (synced across devices if you have Settings Sync enabled). To customize them select `Configure Token Highlight Colors` option from the Command Palette.
@@ -115,9 +130,17 @@ There are currently no known issues. If you encounter a problem, please report i
 
 ## Release Notes
 
-### 1.5.0 - File Pattern Filtering
+### 1.5.0 - HuggingFace Tokenizers & File Pattern Filtering
 
+**New features:**
+
+- **HuggingFace tokenizer family**: load any `tokenizer.json` from the Hub (first launch fetches + caches) or a local file. Byte-level BPE tokenizers (Qwen, Llama, Mistral, etc.) support highlighting; SentencePiece tokenizers that transform whitespace count tokens but skip highlights. Configure via `huggingfaceModelId` or `huggingfaceTokenizerPath`.
 - **New setting `enabledFilePatterns`**: Show status bar only for files matching specific glob patterns (e.g., `["*.md", "*.mdc"]`). Empty array shows for all files.
+
+**Fixes:**
+
+- Token highlighting stays aligned around multi-byte UTF-8 characters (emoji, CJK). The renderer now matches raw bytes against the source instead of decoded token strings, so a token that splits a multi-byte character still lands on the right boundary.
+- Claude highlighting works on documents containing characters that NFKC-normalize to a different form (e.g., full-width `（）` becoming ASCII `()`). Token ranges are reprojected from the normalized tokenization back onto the original text.
 
 ### 1.4.0 - Token Highlighting & Customization
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "gpt-token-counter-live",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gpt-token-counter-live",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",
+        "@huggingface/tokenizers": "^0.1.3",
         "minimatch": "^9.0.0",
         "tiktoken": "^1.0.22"
       },
@@ -133,6 +134,12 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@huggingface/tokenizers": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -303,7 +310,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -821,7 +827,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "typescript": "^5.0.4"
       },
       "engines": {
-        "vscode": "^1.78.0"
+        "vscode": "^1.82.0"
       }
     },
     "node_modules/@anthropic-ai/tokenizer": {
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1583,12 +1583,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gpt-token-counter-live",
   "displayName": "Live LLM Token Counter",
   "description": "Live Token Counter for Language Models",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "publisher": "bedirt",
   "author": {
     "name": "BedirT"
@@ -16,6 +16,7 @@
     "onCommand:gpt-token-counter-live.changeModel",
     "onCommand:gpt-token-counter-live.toggleHighlight",
     "onCommand:gpt-token-counter-live.configureHighlights",
+    "onCommand:gpt-token-counter-live.refreshHuggingfaceCache",
     "onLanguage:plaintext",
     "onLanguage:javascript",
     "onLanguage:typescript"
@@ -26,7 +27,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "^1.78.0"
+    "vscode": "^1.82.0"
   },
   "main": "./src/extension.js",
   "scripts": {
@@ -56,6 +57,7 @@
   },
   "dependencies": {
     "@anthropic-ai/tokenizer": "^0.0.4",
+    "@huggingface/tokenizers": "^0.1.3",
     "minimatch": "^9.0.0",
     "tiktoken": "^1.0.22"
   },
@@ -76,6 +78,10 @@
       {
         "command": "gpt-token-counter-live.configureHighlights",
         "title": "Configure Token Highlight Colors"
+      },
+      {
+        "command": "gpt-token-counter-live.refreshHuggingfaceCache",
+        "title": "Refresh HuggingFace Tokenizer Cache"
       }
     ],
     "configuration": {
@@ -86,7 +92,8 @@
           "enum": [
             "openai",
             "anthropic",
-            "gemini"
+            "gemini",
+            "huggingface"
           ],
           "default": "openai",
           "markdownDescription": "Model family selected by default when the extension activates."
@@ -103,6 +110,18 @@
           },
           "default": [],
           "markdownDescription": "Glob patterns for files where the status bar should be shown (e.g., `[\"*.md\", \"*.mdc\"]`). Empty array shows for all files."
+        },
+        "gpt-token-counter-live.huggingfaceModelId": {
+          "type": "string",
+          "default": "",
+          "scope": "machine",
+          "markdownDescription": "HuggingFace repo ID (e.g. `Qwen/Qwen2.5-7B-Instruct`, `meta-llama/Llama-3-8B`) to load a tokenizer for when the HuggingFace family is active. The extension fetches `tokenizer.json` + `tokenizer_config.json` from `https://huggingface.co/{id}/resolve/main/` once and caches them on disk. Leave empty if you are pointing at a local file with `huggingfaceTokenizerPath`.\n\n*Scope: machine-only. Cannot be set from workspace settings so a repository cannot trigger a remote fetch on your machine without your consent.*"
+        },
+        "gpt-token-counter-live.huggingfaceTokenizerPath": {
+          "type": "string",
+          "default": "",
+          "scope": "machine",
+          "markdownDescription": "Absolute path to a local HuggingFace `tokenizer.json` file. When set, this overrides `huggingfaceModelId`. If a sibling `tokenizer_config.json` exists next to the file it is loaded as well; otherwise the tokenizer loads with default config.\n\n*Scope: machine-only. Cannot be set from workspace settings so a repository cannot direct the extension at arbitrary files on your disk.*"
         }
       }
     }

--- a/src/extension.js
+++ b/src/extension.js
@@ -21,6 +21,8 @@ const MODEL_FAMILIES = {
 
 const HF_CACHE_DIR_NAME = 'hf-tokenizers';
 const HF_HUB_BASE_URL = 'https://huggingface.co';
+const HF_SAFE_ID_READABLE_MAX_LENGTH = 96;
+const HF_SAFE_ID_HASH_LENGTH = 12;
 
 const HIGHLIGHT_EVEN_KEY = 'highlightEvenColor';
 const HIGHLIGHT_ODD_KEY = 'highlightOddColor';
@@ -396,8 +398,9 @@ function deriveHfSafeId(modelId) {
         .replace(/\\/g, '/')
         .replace(/\//g, '--')
         .replace(/[^A-Za-z0-9._-]/g, '_');
-    const hash = crypto.createHash('sha256').update(trimmed).digest('hex').slice(0, 12);
-    return `${readable}_${hash}`;
+    const readablePrefix = readable.slice(0, HF_SAFE_ID_READABLE_MAX_LENGTH) || 'model';
+    const hash = crypto.createHash('sha256').update(trimmed).digest('hex').slice(0, HF_SAFE_ID_HASH_LENGTH);
+    return `${readablePrefix}_${hash}`;
 }
 
 function resolveHuggingfaceSource(config) {
@@ -563,41 +566,59 @@ function huggingfaceTokenizerSupportsHighlight(tokenizer) {
 // On any failure during write/fsync/rename the temp file is unlinked so repeated
 // retries don't accumulate orphan `*.tmp.*` files in globalStorage.
 //
-// `fs.writeSync` may return a partial byte count (disk-full, network FS, signal
+// `FileHandle.write` may return a partial byte count (disk-full, network FS, signal
 // interruption), so we loop until every byte lands before fsync+rename. A single
 // raw call would silently truncate the cache file while still reporting success.
-function writeAtomicFileSync(finalPath, data) {
+async function writeAtomicFile(finalPath, data) {
     const tmpPath = `${finalPath}.tmp.${process.pid}.${Date.now()}`;
+    let fileHandle = null;
     try {
         const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data, 'utf8');
-        const fd = fs.openSync(tmpPath, 'w');
+        fileHandle = await fs.promises.open(tmpPath, 'w');
         try {
             let offset = 0;
             while (offset < buffer.length) {
-                const written = fs.writeSync(fd, buffer, offset, buffer.length - offset);
-                if (written <= 0) {
-                    throw new Error(`writeSync reported 0 bytes written at offset ${offset}/${buffer.length}`);
+                const result = await fileHandle.write(buffer, offset, buffer.length - offset, offset);
+                if (result.bytesWritten <= 0) {
+                    throw new Error(`FileHandle.write reported 0 bytes written at offset ${offset}/${buffer.length}`);
                 }
-                offset += written;
+                offset += result.bytesWritten;
             }
-            fs.fsyncSync(fd);
+            await fileHandle.sync();
         } finally {
-            fs.closeSync(fd);
+            await fileHandle.close();
+            fileHandle = null;
         }
-        fs.renameSync(tmpPath, finalPath);
+        await fs.promises.rename(tmpPath, finalPath);
     } catch (error) {
-        removeFileIfExists(tmpPath);
+        if (fileHandle) {
+            try {
+                await fileHandle.close();
+            } catch (_ignored) {
+                // best-effort cleanup below still runs
+            }
+        }
+        await removeFileIfExists(tmpPath);
         throw error;
     }
 }
 
-function removeFileIfExists(filePath) {
+async function removeFileIfExists(filePath) {
     try {
-        if (fs.existsSync(filePath)) {
-            fs.unlinkSync(filePath);
-        }
+        await fs.promises.unlink(filePath);
     } catch (_ignored) {
         // best-effort cleanup; leave the stale file rather than crash the extension
+    }
+}
+
+async function readTextFileIfExists(filePath, fallback) {
+    try {
+        return await fs.promises.readFile(filePath, 'utf8');
+    } catch (error) {
+        if (error && error.code === 'ENOENT') {
+            return fallback;
+        }
+        throw error;
     }
 }
 
@@ -878,18 +899,22 @@ function activate(context) {
         };
     }
 
-    function ensureHuggingfaceCacheDir() {
+    function getHuggingfaceCacheDir() {
         const base = context.globalStorageUri && context.globalStorageUri.fsPath;
         if (!base) {
             throw new Error('Extension global storage path is unavailable.');
         }
-        const dir = path.join(base, HF_CACHE_DIR_NAME);
-        fs.mkdirSync(dir, { recursive: true });
+        return path.join(base, HF_CACHE_DIR_NAME);
+    }
+
+    async function ensureHuggingfaceCacheDir() {
+        const dir = getHuggingfaceCacheDir();
+        await fs.promises.mkdir(dir, { recursive: true });
         return dir;
     }
 
-    function getHuggingfaceCacheFilePath(safeId, suffix) {
-        const dir = ensureHuggingfaceCacheDir();
+    async function getHuggingfaceCacheFilePath(safeId, suffix) {
+        const dir = await ensureHuggingfaceCacheDir();
         return path.join(dir, `${safeId}${suffix}`);
     }
 
@@ -904,15 +929,17 @@ function activate(context) {
             if (!path.isAbsolute(filePath)) {
                 throw new Error(`HuggingFace tokenizer path must be absolute, got "${filePath}".`);
             }
-            if (!fs.existsSync(filePath)) {
-                throw new Error(`HuggingFace tokenizer file not found at "${filePath}".`);
+            let tokenizerJson;
+            try {
+                tokenizerJson = await fs.promises.readFile(filePath, 'utf8');
+            } catch (error) {
+                if (error && error.code === 'ENOENT') {
+                    throw new Error(`HuggingFace tokenizer file not found at "${filePath}".`);
+                }
+                throw error;
             }
-            const tokenizerJson = fs.readFileSync(filePath, 'utf8');
             const siblingConfig = path.join(path.dirname(filePath), 'tokenizer_config.json');
-            let tokenizerConfigJson = '{}';
-            if (fs.existsSync(siblingConfig)) {
-                tokenizerConfigJson = fs.readFileSync(siblingConfig, 'utf8');
-            }
+            const tokenizerConfigJson = await readTextFileIfExists(siblingConfig, '{}');
             return {
                 tokenizer: buildHuggingfaceTokenizerFromStrings(tokenizerJson, tokenizerConfigJson),
                 loadToken
@@ -920,24 +947,24 @@ function activate(context) {
         }
 
         if (source.kind === 'remote') {
-            const tokenizerPath = getHuggingfaceCacheFilePath(source.safeId, '.json');
-            const configPath = getHuggingfaceCacheFilePath(source.safeId, '.config.json');
+            const tokenizerPath = await getHuggingfaceCacheFilePath(source.safeId, '.json');
+            const configPath = await getHuggingfaceCacheFilePath(source.safeId, '.config.json');
 
             // Try the cache first. Validate by actually parsing + constructing the
             // tokenizer; if that throws, the cache entry is corrupt (interrupted
             // write, cross-window race, truncated disk) so we wipe it and refetch.
-            if (fs.existsSync(tokenizerPath)) {
-                try {
-                    const cachedTokenizerJson = fs.readFileSync(tokenizerPath, 'utf8');
-                    const cachedConfigJson = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf8') : '{}';
-                    return {
-                        tokenizer: buildHuggingfaceTokenizerFromStrings(cachedTokenizerJson, cachedConfigJson),
-                        loadToken
-                    };
-                } catch (cacheError) {
+            try {
+                const cachedTokenizerJson = await fs.promises.readFile(tokenizerPath, 'utf8');
+                const cachedConfigJson = await readTextFileIfExists(configPath, '{}');
+                return {
+                    tokenizer: buildHuggingfaceTokenizerFromStrings(cachedTokenizerJson, cachedConfigJson),
+                    loadToken
+                };
+            } catch (cacheError) {
+                if (!cacheError || cacheError.code !== 'ENOENT') {
                     console.warn(`[gpt-token-counter-live] Discarding corrupt HuggingFace cache for "${source.modelId}" and refetching: ${cacheError.message}`);
-                    removeFileIfExists(tokenizerPath);
-                    removeFileIfExists(configPath);
+                    await removeFileIfExists(tokenizerPath);
+                    await removeFileIfExists(configPath);
                 }
             }
 
@@ -948,8 +975,8 @@ function activate(context) {
             const tokenizer = buildHuggingfaceTokenizerFromStrings(fetched.tokenizerJson, fetched.tokenizerConfigJson);
 
             try {
-                writeAtomicFileSync(tokenizerPath, fetched.tokenizerJson);
-                writeAtomicFileSync(configPath, fetched.tokenizerConfigJson);
+                await writeAtomicFile(tokenizerPath, fetched.tokenizerJson);
+                await writeAtomicFile(configPath, fetched.tokenizerConfigJson);
             } catch (writeError) {
                 console.warn(`[gpt-token-counter-live] Could not cache tokenizer for "${source.modelId}": ${writeError.message}`);
             }
@@ -969,6 +996,13 @@ function activate(context) {
             return;
         }
         if (tokenizerState.hfStatus !== 'error') {
+            return;
+        }
+        if (tokenizerState.hfErrorLabel === '<no-config>') {
+            return;
+        }
+        const source = resolveHuggingfaceSource(readHuggingfaceConfigFromVscode());
+        if (source.kind === 'none') {
             return;
         }
         if (Date.now() - (tokenizerState.hfLastAttemptAt || 0) < HF_RETRY_COOLDOWN_MS) {
@@ -1450,7 +1484,7 @@ function activate(context) {
     // we fetch `resolve/main` (mutable) and cache indefinitely, so an upstream tokenizer
     // change would otherwise silently drift token counts. Users can invoke this from the
     // Command Palette to force a re-fetch.
-    const refreshHuggingfaceCache = vscode.commands.registerCommand('gpt-token-counter-live.refreshHuggingfaceCache', () => {
+    const refreshHuggingfaceCache = vscode.commands.registerCommand('gpt-token-counter-live.refreshHuggingfaceCache', async () => {
         if (currentProvider !== 'huggingface') {
             vscode.window.showInformationMessage('Switch to the HuggingFace model family before refreshing its tokenizer cache.');
             return;
@@ -1458,8 +1492,8 @@ function activate(context) {
         const hfConfig = readHuggingfaceConfigFromVscode();
         const source = resolveHuggingfaceSource(hfConfig);
         if (source.kind === 'remote') {
-            removeFileIfExists(getHuggingfaceCacheFilePath(source.safeId, '.json'));
-            removeFileIfExists(getHuggingfaceCacheFilePath(source.safeId, '.config.json'));
+            await removeFileIfExists(await getHuggingfaceCacheFilePath(source.safeId, '.json'));
+            await removeFileIfExists(await getHuggingfaceCacheFilePath(source.safeId, '.config.json'));
             vscode.window.showInformationMessage(`HuggingFace tokenizer cache cleared for "${source.modelId}". Refetching...`);
         } else if (source.kind === 'local') {
             vscode.window.showInformationMessage(`Reloading HuggingFace tokenizer from "${source.path}"...`);

--- a/src/extension.js
+++ b/src/extension.js
@@ -507,9 +507,13 @@ async function fetchHuggingfaceTokenizerFiles(modelId) {
     // Bound every network round trip so a stalled proxy can't pin `hfStatus` at `loading`
     // forever. On abort the promise rejects, `beginHuggingfaceLoad`'s catch flips status to
     // `error`, and `maybeRetryHuggingfaceLoad` can fire again after the cooldown.
-    const signal = AbortSignal.timeout(HF_FETCH_TIMEOUT_MS);
+    // Each fetch gets a FRESH timeout signal: a single shared `AbortSignal.timeout(...)`
+    // starts counting the moment it's created, so a slow `tokenizer.json` would eat into
+    // the `tokenizer_config.json` budget or abort it immediately.
 
-    const tokenizerResp = await fetch(`${baseUrl}/tokenizer.json`, { signal });
+    const tokenizerResp = await fetch(`${baseUrl}/tokenizer.json`, {
+        signal: AbortSignal.timeout(HF_FETCH_TIMEOUT_MS)
+    });
     if (!tokenizerResp.ok) {
         throw new Error(`Failed to fetch tokenizer.json for "${modelId}" (HTTP ${tokenizerResp.status}).`);
     }
@@ -520,7 +524,9 @@ async function fetchHuggingfaceTokenizerFiles(modelId) {
     // transient failure would poison the cache with wrong-count results. Treat 404 (repo
     // legitimately does not ship it) as the only non-fatal outcome; everything else throws.
     let tokenizerConfigJson = '{}';
-    const configResp = await fetch(`${baseUrl}/tokenizer_config.json`, { signal });
+    const configResp = await fetch(`${baseUrl}/tokenizer_config.json`, {
+        signal: AbortSignal.timeout(HF_FETCH_TIMEOUT_MS)
+    });
     if (configResp.ok) {
         tokenizerConfigJson = await configResp.text();
     } else if (configResp.status !== 404) {
@@ -556,12 +562,24 @@ function huggingfaceTokenizerSupportsHighlight(tokenizer) {
 // A crash or concurrent writer can no longer leave a half-written file at finalPath.
 // On any failure during write/fsync/rename the temp file is unlinked so repeated
 // retries don't accumulate orphan `*.tmp.*` files in globalStorage.
+//
+// `fs.writeSync` may return a partial byte count (disk-full, network FS, signal
+// interruption), so we loop until every byte lands before fsync+rename. A single
+// raw call would silently truncate the cache file while still reporting success.
 function writeAtomicFileSync(finalPath, data) {
     const tmpPath = `${finalPath}.tmp.${process.pid}.${Date.now()}`;
     try {
+        const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data, 'utf8');
         const fd = fs.openSync(tmpPath, 'w');
         try {
-            fs.writeSync(fd, data);
+            let offset = 0;
+            while (offset < buffer.length) {
+                const written = fs.writeSync(fd, buffer, offset, buffer.length - offset);
+                if (written <= 0) {
+                    throw new Error(`writeSync reported 0 bytes written at offset ${offset}/${buffer.length}`);
+                }
+                offset += written;
+            }
             fs.fsyncSync(fd);
         } finally {
             fs.closeSync(fd);

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,6 +1,10 @@
 const vscode = require('vscode');
+const path = require('path');
+const fs = require('fs');
+const crypto = require('crypto');
 const { encoding_for_model, get_encoding } = require('tiktoken');
 const { countTokens, getTokenizer } = require('@anthropic-ai/tokenizer');
+const { Tokenizer: HuggingfaceTokenizer } = require('@huggingface/tokenizers');
 const { minimatch } = require('minimatch');
 
 const CONFIG_SECTION = 'gpt-token-counter-live';
@@ -11,8 +15,12 @@ const DEFAULT_STATUS_TEMPLATE = 'Token Count: {count} ({family})';
 const MODEL_FAMILIES = {
     'openai': 'GPT',
     'anthropic': 'Claude',
-    'gemini': 'Gemini'
+    'gemini': 'Gemini',
+    'huggingface': 'HuggingFace'
 };
+
+const HF_CACHE_DIR_NAME = 'hf-tokenizers';
+const HF_HUB_BASE_URL = 'https://huggingface.co';
 
 const HIGHLIGHT_EVEN_KEY = 'highlightEvenColor';
 const HIGHLIGHT_ODD_KEY = 'highlightOddColor';
@@ -372,8 +380,222 @@ function createTokenDecorationTypes() {
     };
 }
 
+function deriveHfSafeId(modelId) {
+    if (typeof modelId !== 'string') {
+        return '';
+    }
+    const trimmed = modelId.trim();
+    if (!trimmed) {
+        return '';
+    }
+    // Build a readable prefix for cache debuggability, then append a short hash of the
+    // original model ID. The hash guarantees the mapping is injective, so inputs whose
+    // readable forms would collide (e.g. `a/b--c` and `a--b/c` both reduce to `a--b--c`)
+    // still resolve to distinct cache filenames and do not poison each other.
+    const readable = trimmed
+        .replace(/\\/g, '/')
+        .replace(/\//g, '--')
+        .replace(/[^A-Za-z0-9._-]/g, '_');
+    const hash = crypto.createHash('sha256').update(trimmed).digest('hex').slice(0, 12);
+    return `${readable}_${hash}`;
+}
+
+function resolveHuggingfaceSource(config) {
+    const modelId = typeof config.modelId === 'string' ? config.modelId.trim() : '';
+    const localPath = typeof config.localPath === 'string' ? config.localPath.trim() : '';
+
+    if (localPath) {
+        return { kind: 'local', path: localPath };
+    }
+    if (modelId) {
+        return { kind: 'remote', modelId, safeId: deriveHfSafeId(modelId) };
+    }
+    return { kind: 'none' };
+}
+
+function readHuggingfaceConfigFromVscode() {
+    const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
+    return {
+        modelId: config.get('huggingfaceModelId') || '',
+        localPath: config.get('huggingfaceTokenizerPath') || ''
+    };
+}
+
+/**
+ * Walks a token id array and produces character offsets in the decoded text by
+ * progressively decoding each id. Byte-level BPE tokenizers emit multi-byte
+ * characters across several consecutive ids; we group those ids together and
+ * attribute the full run to the first id in the group (remaining ids get a
+ * zero-length range so indexing matches).
+ *
+ * Returns `{ offsets, decoded, aligned }`. `aligned` is `true` only when the
+ * full decode matches `text`, which is the guard we use before rendering
+ * highlights. SentencePiece and other decoder-cleaning tokenizers can drop
+ * leading whitespace and produce a text-shaped but offset-shifted output.
+ *
+ * @param {Object} tokenizer  An `@huggingface/tokenizers` Tokenizer instance.
+ * @param {string} text       The original source text.
+ * @param {number[]} ids      Token ids produced by `tokenizer.encode(text).ids`.
+ */
+function reconstructHuggingfaceOffsets(tokenizer, text, ids) {
+    if (!Array.isArray(ids) || ids.length === 0) {
+        return { offsets: [], decoded: '', aligned: text.length === 0 };
+    }
+
+    const decodeOptions = { skip_special_tokens: false, clean_up_tokenization_spaces: false };
+    const FFFD = '\uFFFD';
+
+    const endsWithHighSurrogate = (str) => str.length > 0 && /[\uD800-\uDBFF]$/.test(str);
+    const needsContinuation = (str) => str.includes(FFFD) || endsWithHighSurrogate(str);
+
+    const offsets = new Array(ids.length);
+    let cursor = 0;
+    let i = 0;
+    let decoded = '';
+
+    while (i < ids.length) {
+        let piece;
+        try {
+            piece = tokenizer.decode([ids[i]], decodeOptions);
+        } catch (error) {
+            return { offsets, decoded, aligned: false, error };
+        }
+
+        if (!needsContinuation(piece)) {
+            offsets[i] = [cursor, cursor + piece.length];
+            cursor += piece.length;
+            decoded += piece;
+            i += 1;
+            continue;
+        }
+
+        // Group this id with subsequent ids until the cumulative decode is a
+        // well-formed string. Attribute the whole range to the first id and
+        // give the follower ids a zero-length slice anchored at the group end.
+        let end = i + 1;
+        let groupDecoded = piece;
+        while (end < ids.length && needsContinuation(groupDecoded)) {
+            try {
+                groupDecoded = tokenizer.decode(ids.slice(i, end + 1), decodeOptions);
+            } catch (error) {
+                return { offsets, decoded, aligned: false, error };
+            }
+            end += 1;
+        }
+
+        const groupEnd = cursor + groupDecoded.length;
+        offsets[i] = [cursor, groupEnd];
+        for (let k = i + 1; k < end; k++) {
+            offsets[k] = [groupEnd, groupEnd];
+        }
+        decoded += groupDecoded;
+        cursor = groupEnd;
+        i = end;
+    }
+
+    const aligned = decoded === text;
+    return { offsets, decoded, aligned };
+}
+
+async function fetchHuggingfaceTokenizerFiles(modelId) {
+    if (typeof fetch !== 'function') {
+        throw new Error('Global fetch is not available. VS Code 1.82+ / Node 18+ is required to load HuggingFace tokenizers from the Hub.');
+    }
+
+    const baseUrl = `${HF_HUB_BASE_URL}/${modelId}/resolve/main`;
+
+    // Bound every network round trip so a stalled proxy can't pin `hfStatus` at `loading`
+    // forever. On abort the promise rejects, `beginHuggingfaceLoad`'s catch flips status to
+    // `error`, and `maybeRetryHuggingfaceLoad` can fire again after the cooldown.
+    const signal = AbortSignal.timeout(HF_FETCH_TIMEOUT_MS);
+
+    const tokenizerResp = await fetch(`${baseUrl}/tokenizer.json`, { signal });
+    if (!tokenizerResp.ok) {
+        throw new Error(`Failed to fetch tokenizer.json for "${modelId}" (HTTP ${tokenizerResp.status}).`);
+    }
+    const tokenizerJson = await tokenizerResp.text();
+
+    // tokenizer_config.json drives rules like `remove_space`, `do_lowercase_and_remove_accent`,
+    // `eos_token`, and `target_lang` for Unigram/legacy tokenizers, so silently swallowing a
+    // transient failure would poison the cache with wrong-count results. Treat 404 (repo
+    // legitimately does not ship it) as the only non-fatal outcome; everything else throws.
+    let tokenizerConfigJson = '{}';
+    const configResp = await fetch(`${baseUrl}/tokenizer_config.json`, { signal });
+    if (configResp.ok) {
+        tokenizerConfigJson = await configResp.text();
+    } else if (configResp.status !== 404) {
+        throw new Error(`Failed to fetch tokenizer_config.json for "${modelId}" (HTTP ${configResp.status}).`);
+    }
+
+    return { tokenizerJson, tokenizerConfigJson };
+}
+
+function buildHuggingfaceTokenizerFromStrings(tokenizerJson, tokenizerConfigJson) {
+    const tokenizerObj = JSON.parse(tokenizerJson);
+    const configObj = tokenizerConfigJson ? JSON.parse(tokenizerConfigJson) : {};
+    return new HuggingfaceTokenizer(tokenizerObj, configObj);
+}
+
+// Probe whether `reconstructHuggingfaceOffsets` will produce aligned offsets for this tokenizer.
+// SentencePiece/WordPiece variants and other whitespace-normalizing decoders cannot round-trip,
+// so we detect that at load time and advertise highlight support accordingly. A probe that mixes
+// leading whitespace, punctuation, and multi-line text catches the common non-roundtripping cases.
+const HF_HIGHLIGHT_PROBE_TEXT = ' Hello, world!\nSecond line.';
+function huggingfaceTokenizerSupportsHighlight(tokenizer) {
+    try {
+        const encoded = tokenizer.encode(HF_HIGHLIGHT_PROBE_TEXT, { add_special_tokens: false });
+        const ids = Array.isArray(encoded && encoded.ids) ? encoded.ids : [];
+        const result = reconstructHuggingfaceOffsets(tokenizer, HF_HIGHLIGHT_PROBE_TEXT, ids);
+        return result.aligned === true;
+    } catch (_error) {
+        return false;
+    }
+}
+
+// Write `data` to `finalPath` atomically: stage to a temp file, fsync, rename.
+// A crash or concurrent writer can no longer leave a half-written file at finalPath.
+// On any failure during write/fsync/rename the temp file is unlinked so repeated
+// retries don't accumulate orphan `*.tmp.*` files in globalStorage.
+function writeAtomicFileSync(finalPath, data) {
+    const tmpPath = `${finalPath}.tmp.${process.pid}.${Date.now()}`;
+    try {
+        const fd = fs.openSync(tmpPath, 'w');
+        try {
+            fs.writeSync(fd, data);
+            fs.fsyncSync(fd);
+        } finally {
+            fs.closeSync(fd);
+        }
+        fs.renameSync(tmpPath, finalPath);
+    } catch (error) {
+        removeFileIfExists(tmpPath);
+        throw error;
+    }
+}
+
+function removeFileIfExists(filePath) {
+    try {
+        if (fs.existsSync(filePath)) {
+            fs.unlinkSync(filePath);
+        }
+    } catch (_ignored) {
+        // best-effort cleanup; leave the stale file rather than crash the extension
+    }
+}
+
+const HF_RETRY_COOLDOWN_MS = 30000;
+const HF_FETCH_TIMEOUT_MS = 30000;
+
 let tokenizerState = {
+    kind: null,
     encoder: null,
+    hfTokenizer: null,
+    hfStatus: 'idle',
+    hfModelId: '',
+    hfLocalPath: '',
+    hfLoadToken: 0,
+    hfLastAttemptAt: 0,
+    hfErrorLabel: null,
     supportsHighlight: false,
     requiresNormalization: false
 };
@@ -408,6 +630,9 @@ function activate(context) {
     let currentProvider = getDefaultProviderFromConfig();
     let currentFamilyName = MODEL_FAMILIES[currentProvider];
     let highlightEnabled = false;
+    // Tracks the last (document uri, HF model) pair we warned about for round-trip
+    // misalignment so we don't spam the dev console on every keystroke.
+    let lastHfHighlightWarnKey = null;
 
     context.subscriptions.push(
         statusBar,
@@ -617,14 +842,181 @@ function activate(context) {
     }
 
     function resetTokenizerState() {
-        if (tokenizerState.encoder) {
+        if (tokenizerState.encoder && typeof tokenizerState.encoder.free === 'function') {
             tokenizerState.encoder.free();
         }
         tokenizerState = {
+            kind: null,
             encoder: null,
+            hfTokenizer: null,
+            hfStatus: 'idle',
+            hfModelId: '',
+            hfLocalPath: '',
+            hfLoadToken: tokenizerState.hfLoadToken + 1, // invalidate any pending async load
+            hfLastAttemptAt: 0,
+            hfErrorLabel: null,
             supportsHighlight: false,
             requiresNormalization: false
         };
+    }
+
+    function ensureHuggingfaceCacheDir() {
+        const base = context.globalStorageUri && context.globalStorageUri.fsPath;
+        if (!base) {
+            throw new Error('Extension global storage path is unavailable.');
+        }
+        const dir = path.join(base, HF_CACHE_DIR_NAME);
+        fs.mkdirSync(dir, { recursive: true });
+        return dir;
+    }
+
+    function getHuggingfaceCacheFilePath(safeId, suffix) {
+        const dir = ensureHuggingfaceCacheDir();
+        return path.join(dir, `${safeId}${suffix}`);
+    }
+
+    async function loadHuggingfaceTokenizerFromSource(source, loadToken) {
+        if (source.kind === 'local') {
+            const filePath = source.path;
+            // The setting is documented as an absolute path. Relative paths resolve against
+            // `process.cwd()`, which in the VS Code extension host is non-deterministic
+            // (workspace root when launched from a terminal, the VS Code install dir when
+            // launched from an app icon). Surface that explicitly instead of failing with a
+            // misleading "not found" error using the literal relative string.
+            if (!path.isAbsolute(filePath)) {
+                throw new Error(`HuggingFace tokenizer path must be absolute, got "${filePath}".`);
+            }
+            if (!fs.existsSync(filePath)) {
+                throw new Error(`HuggingFace tokenizer file not found at "${filePath}".`);
+            }
+            const tokenizerJson = fs.readFileSync(filePath, 'utf8');
+            const siblingConfig = path.join(path.dirname(filePath), 'tokenizer_config.json');
+            let tokenizerConfigJson = '{}';
+            if (fs.existsSync(siblingConfig)) {
+                tokenizerConfigJson = fs.readFileSync(siblingConfig, 'utf8');
+            }
+            return {
+                tokenizer: buildHuggingfaceTokenizerFromStrings(tokenizerJson, tokenizerConfigJson),
+                loadToken
+            };
+        }
+
+        if (source.kind === 'remote') {
+            const tokenizerPath = getHuggingfaceCacheFilePath(source.safeId, '.json');
+            const configPath = getHuggingfaceCacheFilePath(source.safeId, '.config.json');
+
+            // Try the cache first. Validate by actually parsing + constructing the
+            // tokenizer; if that throws, the cache entry is corrupt (interrupted
+            // write, cross-window race, truncated disk) so we wipe it and refetch.
+            if (fs.existsSync(tokenizerPath)) {
+                try {
+                    const cachedTokenizerJson = fs.readFileSync(tokenizerPath, 'utf8');
+                    const cachedConfigJson = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf8') : '{}';
+                    return {
+                        tokenizer: buildHuggingfaceTokenizerFromStrings(cachedTokenizerJson, cachedConfigJson),
+                        loadToken
+                    };
+                } catch (cacheError) {
+                    console.warn(`[gpt-token-counter-live] Discarding corrupt HuggingFace cache for "${source.modelId}" and refetching: ${cacheError.message}`);
+                    removeFileIfExists(tokenizerPath);
+                    removeFileIfExists(configPath);
+                }
+            }
+
+            // Cache miss or self-healed from a corrupt entry. Fetch, build (which
+            // validates the JSON), then only persist to the cache after we know
+            // the data produces a usable tokenizer.
+            const fetched = await fetchHuggingfaceTokenizerFiles(source.modelId);
+            const tokenizer = buildHuggingfaceTokenizerFromStrings(fetched.tokenizerJson, fetched.tokenizerConfigJson);
+
+            try {
+                writeAtomicFileSync(tokenizerPath, fetched.tokenizerJson);
+                writeAtomicFileSync(configPath, fetched.tokenizerConfigJson);
+            } catch (writeError) {
+                console.warn(`[gpt-token-counter-live] Could not cache tokenizer for "${source.modelId}": ${writeError.message}`);
+            }
+
+            return { tokenizer, loadToken };
+        }
+
+        throw new Error('Set `huggingfaceModelId` (e.g. "Qwen/Qwen2.5-7B-Instruct") or `huggingfaceTokenizerPath` to use the HuggingFace tokenizer.');
+    }
+
+    // Fire-and-forget retry when the HF tokenizer failed to load earlier. Triggered from
+    // the tokenization hot path so the first keystroke after a network recovery (or after
+    // the user drops a local tokenizer.json into the configured path) picks it up.
+    // Throttled to avoid hammering the hub during sustained outages.
+    function maybeRetryHuggingfaceLoad() {
+        if (currentProvider !== 'huggingface') {
+            return;
+        }
+        if (tokenizerState.hfStatus !== 'error') {
+            return;
+        }
+        if (Date.now() - (tokenizerState.hfLastAttemptAt || 0) < HF_RETRY_COOLDOWN_MS) {
+            return;
+        }
+        void beginHuggingfaceLoad();
+    }
+
+    async function beginHuggingfaceLoad() {
+        const hfConfig = readHuggingfaceConfigFromVscode();
+        const source = resolveHuggingfaceSource(hfConfig);
+        const loadToken = tokenizerState.hfLoadToken;
+        // Snapshot whether we were already advertising an error before this attempt.
+        // Used below to gate the error notification so the throttled retry loop doesn't
+        // pop a fresh toast every 30 seconds for the same sustained failure.
+        const wasAlreadyErrored = tokenizerState.hfStatus === 'error';
+        const previousErrorLabel = tokenizerState.hfErrorLabel || null;
+
+        tokenizerState.kind = 'huggingface';
+        tokenizerState.hfStatus = 'loading';
+        tokenizerState.hfTokenizer = null;
+        tokenizerState.hfModelId = hfConfig.modelId;
+        tokenizerState.hfLocalPath = hfConfig.localPath;
+        tokenizerState.hfLastAttemptAt = Date.now();
+        tokenizerState.supportsHighlight = false;
+
+        if (source.kind === 'none') {
+            tokenizerState.hfStatus = 'error';
+            tokenizerState.hfErrorLabel = '<no-config>';
+            if (!wasAlreadyErrored || previousErrorLabel !== '<no-config>') {
+                vscode.window.showErrorMessage('HuggingFace tokenizer is active but no model ID or local tokenizer path is configured. Open settings and set `gpt-token-counter-live.huggingfaceModelId` or `gpt-token-counter-live.huggingfaceTokenizerPath`.');
+            }
+            updateHighlightStatusBar();
+            await updateTokenCount();
+            return;
+        }
+
+        try {
+            const { tokenizer, loadToken: returnedToken } = await loadHuggingfaceTokenizerFromSource(source, loadToken);
+            // A concurrent reset (provider change, config change) may have invalidated this load.
+            if (returnedToken !== tokenizerState.hfLoadToken || tokenizerState.kind !== 'huggingface') {
+                return;
+            }
+            tokenizerState.hfTokenizer = tokenizer;
+            tokenizerState.hfStatus = 'ready';
+            tokenizerState.hfErrorLabel = null;
+            tokenizerState.supportsHighlight = huggingfaceTokenizerSupportsHighlight(tokenizer);
+        } catch (error) {
+            // Mirror the success-branch guard. Without the `loadToken` check, a stale A-load
+            // that rejects after B-load succeeded would overwrite B's good state with an
+            // error and a toast referencing the wrong model.
+            if (loadToken !== tokenizerState.hfLoadToken || tokenizerState.kind !== 'huggingface') {
+                return;
+            }
+            tokenizerState.hfStatus = 'error';
+            tokenizerState.hfTokenizer = null;
+            tokenizerState.supportsHighlight = false;
+            const label = source.kind === 'local' ? source.path : source.modelId;
+            tokenizerState.hfErrorLabel = label;
+            if (!wasAlreadyErrored || previousErrorLabel !== label) {
+                vscode.window.showErrorMessage(`Failed to load HuggingFace tokenizer for "${label}": ${error.message}`);
+            }
+        }
+
+        updateHighlightStatusBar();
+        await updateTokenCount();
     }
 
     // Function to initialize the encoder for the selected family
@@ -647,11 +1039,13 @@ function activate(context) {
                 }
             }
             if (candidate) {
+                tokenizerState.kind = 'tiktoken';
                 tokenizerState.encoder = candidate;
                 tokenizerState.supportsHighlight = true;
             }
         } else if (provider === 'anthropic') {
             try {
+                tokenizerState.kind = 'anthropic';
                 tokenizerState.encoder = getTokenizer();
                 tokenizerState.supportsHighlight = true;
                 tokenizerState.requiresNormalization = true;
@@ -660,17 +1054,24 @@ function activate(context) {
             }
         } else if (provider === 'gemini') {
             try {
+                tokenizerState.kind = 'tiktoken';
                 tokenizerState.encoder = get_encoding('o200k_base');
             } catch (e1) {
                 try {
+                    tokenizerState.kind = 'tiktoken';
                     tokenizerState.encoder = get_encoding('cl100k_base');
                 } catch (e2) {
+                    tokenizerState.kind = null;
                     tokenizerState.encoder = null;
                 }
             }
+        } else if (provider === 'huggingface') {
+            // HuggingFace loads asynchronously; the counter and highlight use the fallback
+            // until the tokenizer is ready, then `beginHuggingfaceLoad` triggers a re-render.
+            void beginHuggingfaceLoad();
         }
 
-        if (highlightEnabled && !tokenizerState.supportsHighlight) {
+        if (highlightEnabled && !tokenizerState.supportsHighlight && provider !== 'huggingface') {
             highlightEnabled = false;
             clearTokenHighlights();
             vscode.window.showInformationMessage('Token highlighting disabled because the selected model family does not expose precise token boundaries.');
@@ -684,8 +1085,8 @@ function activate(context) {
             return countTokens(text);
         }
 
-        if (currentProvider === 'gemini') {
-            // Fallback approximation: ~4 characters per token
+        // Everyone else (gemini and huggingface while loading) falls back to the 4-chars/token heuristic.
+        if (currentProvider === 'gemini' || currentProvider === 'huggingface') {
             return Math.ceil(text.length / 4);
         }
 
@@ -693,6 +1094,50 @@ function activate(context) {
     }
 
     function computeTokenization(text) {
+        if (tokenizerState.kind === 'huggingface') {
+            if (tokenizerState.hfStatus !== 'ready' || !tokenizerState.hfTokenizer) {
+                // Previous load failed and the session has been sitting on ~4-char/token
+                // approximations. Kick off a throttled retry so counts become accurate as
+                // soon as the underlying problem (network, missing local file) is fixed.
+                maybeRetryHuggingfaceLoad();
+                return {
+                    tokenCount: fallbackTokenCount(text),
+                    tokenizationResult: null
+                };
+            }
+            try {
+                const encoded = tokenizerState.hfTokenizer.encode(text, { add_special_tokens: false });
+                const ids = encoded.ids || [];
+                // Offset reconstruction runs a per-token `decode()` and is the expensive part
+                // of the HF hot path. Skip it when the user isn't highlighting (so plain count
+                // updates stay cheap) and when the tokenizer already failed the load-time
+                // probe (so we don't pay the cost only to throw the result away).
+                const shouldReconstructOffsets = highlightEnabled && tokenizerState.supportsHighlight;
+                const reconstruction = shouldReconstructOffsets
+                    ? reconstructHuggingfaceOffsets(tokenizerState.hfTokenizer, text, ids)
+                    : { offsets: [], aligned: false };
+                return {
+                    tokenCount: ids.length,
+                    tokenizationResult: {
+                        kind: 'huggingface',
+                        ids,
+                        tokens: encoded.tokens || [],
+                        offsets: reconstruction.offsets,
+                        aligned: reconstruction.aligned
+                    }
+                };
+            } catch (error) {
+                vscode.window.showErrorMessage(`HuggingFace tokenization failed: ${error.message}`);
+                tokenizerState.hfStatus = 'error';
+                tokenizerState.hfTokenizer = null;
+                tokenizerState.supportsHighlight = false;
+                return {
+                    tokenCount: fallbackTokenCount(text),
+                    tokenizationResult: null
+                };
+            }
+        }
+
         if (tokenizerState.encoder) {
             const processedText = tokenizerState.requiresNormalization ? text.normalize('NFKC') : text;
             try {
@@ -703,6 +1148,7 @@ function activate(context) {
                 return {
                     tokenCount: encoded.length,
                     tokenizationResult: {
+                        kind: 'tiktoken',
                         tokens: encoded,
                         normalizationChanged: tokenizerState.requiresNormalization && processedText !== text,
                         processedText,
@@ -721,7 +1167,62 @@ function activate(context) {
         };
     }
 
-    let updateTokenCount = () => {
+    function applyHuggingfaceTokenHighlights(editor, baseOffset, tokenizationResult) {
+        if (!editor || !tokenizationResult || !tokenizationResult.aligned) {
+            clearTokenHighlights(editor);
+            if (tokenizationResult && !tokenizationResult.aligned) {
+                // updateTokenCount fires on every keystroke and selection change, so an
+                // unconditional warn would flood the dev console. Emit only when the
+                // (document, model) pair transitions into the misaligned state.
+                const key = `${editor.document.uri.toString()}::${tokenizerState.hfModelId || ''}`;
+                if (lastHfHighlightWarnKey !== key) {
+                    lastHfHighlightWarnKey = key;
+                    console.warn('[gpt-token-counter-live] HuggingFace token highlight skipped because decode round-trip does not match the source text. This happens with tokenizers that strip or transform whitespace (for example many SentencePiece tokenizers).');
+                }
+            }
+            return;
+        }
+        lastHfHighlightWarnKey = null;
+
+        if (!isHighlightableEditor(editor)) {
+            clearTokenHighlights(editor);
+            return;
+        }
+
+        const evenRanges = [];
+        const oddRanges = [];
+        const document = editor.document;
+        const offsets = tokenizationResult.offsets || [];
+
+        // Alternation parity tracks *visible* tokens. `reconstructHuggingfaceOffsets`
+        // emits zero-length continuation entries for multi-id groups (CJK, emoji under
+        // byte-level BPE), and using the raw loop index would cause two adjacent visible
+        // tokens to share a color whenever a group has an even number of followers.
+        let visibleIndex = 0;
+        for (let i = 0; i < offsets.length; i++) {
+            const [start, end] = offsets[i];
+            if (start === end) {
+                continue;
+            }
+            const startPos = document.positionAt(baseOffset + start);
+            const endPos = document.positionAt(baseOffset + end);
+            const range = new vscode.Range(startPos, endPos);
+            if (range.isEmpty) {
+                continue;
+            }
+            if (visibleIndex % 2 === 0) {
+                evenRanges.push(range);
+            } else {
+                oddRanges.push(range);
+            }
+            visibleIndex++;
+        }
+
+        editor.setDecorations(tokenDecorations.even, evenRanges);
+        editor.setDecorations(tokenDecorations.odd, oddRanges);
+    }
+
+    async function updateTokenCount() {
         const editor = vscode.window.activeTextEditor;
         if (!editor) {
             statusBar.hide();
@@ -761,6 +1262,8 @@ function activate(context) {
         if (highlightEnabled) {
             if (!tokenizerState.supportsHighlight) {
                 clearTokenHighlights(editor);
+            } else if (tokenizationResult && tokenizationResult.kind === 'huggingface') {
+                applyHuggingfaceTokenHighlights(editor, baseOffset, tokenizationResult);
             } else {
                 applyTokenHighlights(editor, text, baseOffset, tokenizationResult);
             }
@@ -769,17 +1272,25 @@ function activate(context) {
         }
 
         updateHighlightStatusBar();
-    };
+    }
 
-    vscode.window.onDidChangeTextEditorSelection(updateTokenCount, null, context.subscriptions);
-    vscode.window.onDidChangeActiveTextEditor(updateTokenCount, null, context.subscriptions);
-    vscode.workspace.onDidChangeTextDocument(updateTokenCount, null, context.subscriptions);
+    const scheduleUpdateTokenCount = () => { void updateTokenCount(); };
+
+    vscode.window.onDidChangeTextEditorSelection(scheduleUpdateTokenCount, null, context.subscriptions);
+    vscode.window.onDidChangeActiveTextEditor(scheduleUpdateTokenCount, null, context.subscriptions);
+    vscode.workspace.onDidChangeTextDocument(scheduleUpdateTokenCount, null, context.subscriptions);
 
     vscode.workspace.onDidChangeConfiguration(event => {
         if (event.affectsConfiguration(`${CONFIG_SECTION}.statusBarDisplayTemplate`)) {
             loadStatusBarConfig();
-            updateTokenCount();
+            scheduleUpdateTokenCount();
         }
+
+        // Track whether this event already re-initialized the HF tokenizer so a single
+        // settings save that touches both `defaultModelFamily` and `huggingfaceModelId`
+        // doesn't trigger two concurrent `beginHuggingfaceLoad()` calls (doubled fetch,
+        // racing atomic writes onto the same cache path).
+        let reinitializedInThisEvent = false;
 
         if (event.affectsConfiguration(`${CONFIG_SECTION}.defaultModelFamily`)) {
             const desiredProvider = getDefaultProviderFromConfig();
@@ -789,28 +1300,50 @@ function activate(context) {
 
                 try {
                     initializeEncoderForFamily(currentProvider);
+                    reinitializedInThisEvent = true;
                 } catch (error) {
                     vscode.window.showErrorMessage(`Failed to initialize tokenizer for ${currentFamilyName}: ${error.message}`);
                 }
 
-                updateTokenCount();
+                scheduleUpdateTokenCount();
             }
         }
 
         if (event.affectsConfiguration(`${CONFIG_SECTION}.enabledFilePatterns`)) {
             loadEnabledFilePatterns();
-            updateTokenCount();
+            scheduleUpdateTokenCount();
+        }
+
+        if (!reinitializedInThisEvent && currentProvider === 'huggingface' && (
+            event.affectsConfiguration(`${CONFIG_SECTION}.huggingfaceModelId`) ||
+            event.affectsConfiguration(`${CONFIG_SECTION}.huggingfaceTokenizerPath`)
+        )) {
+            // Re-run initialization so a fresh beginHuggingfaceLoad kicks off.
+            try {
+                initializeEncoderForFamily(currentProvider);
+            } catch (error) {
+                vscode.window.showErrorMessage(`Failed to reload HuggingFace tokenizer: ${error.message}`);
+            }
+            scheduleUpdateTokenCount();
         }
     }, null, context.subscriptions);
 
     let disposable = vscode.commands.registerCommand('gpt-token-counter-live.changeModel', async function () {
+        const providerDetail = (provider) => {
+            if (provider === 'gemini') {
+                return 'Approximate tokenizer (highlighting unavailable)';
+            }
+            if (provider === 'huggingface') {
+                return 'HuggingFace tokenizer.json (configure via settings)';
+            }
+            return 'Precise tokenizer with highlighting';
+        };
+
         /** @type {(vscode.QuickPickItem & { provider?: string, family?: string, command?: string })[]} */
         const familyItems = Object.entries(MODEL_FAMILIES).map(([provider, family]) => ({
             label: `${family} (${provider})`,
             description: provider === currentProvider ? 'Currently active' : undefined,
-            detail: provider === 'gemini'
-                ? 'Approximate tokenizer (highlighting unavailable)'
-                : 'Precise tokenizer with highlighting',
+            detail: providerDetail(provider),
             provider,
             family,
             picked: provider === currentProvider
@@ -858,7 +1391,7 @@ function activate(context) {
                     // Continue with approximation where applicable
                 }
 
-                updateTokenCount();
+                scheduleUpdateTokenCount();
             }
         }
     });
@@ -869,7 +1402,13 @@ function activate(context) {
         const nextState = !highlightEnabled;
 
         if (nextState && !tokenizerState.supportsHighlight) {
-            vscode.window.showInformationMessage('Token highlighting is only available for GPT and Claude tokenizers.');
+            if (currentProvider === 'huggingface' && tokenizerState.hfStatus === 'loading') {
+                vscode.window.showInformationMessage('HuggingFace tokenizer is still loading. Try again once the download finishes.');
+            } else if (currentProvider === 'huggingface') {
+                vscode.window.showInformationMessage('Token highlighting is unavailable until a HuggingFace tokenizer is loaded successfully.');
+            } else {
+                vscode.window.showInformationMessage('Token highlighting is only available for GPT, Claude, and HuggingFace tokenizers.');
+            }
             highlightEnabled = false;
         } else if (nextState) {
             highlightEnabled = true;
@@ -884,10 +1423,41 @@ function activate(context) {
         }
 
         updateHighlightStatusBar();
-        updateTokenCount();
+        scheduleUpdateTokenCount();
     });
 
     context.subscriptions.push(toggleHighlight);
+
+    // Manual cache-bust for the HuggingFace remote tokenizer. Addresses the fact that
+    // we fetch `resolve/main` (mutable) and cache indefinitely, so an upstream tokenizer
+    // change would otherwise silently drift token counts. Users can invoke this from the
+    // Command Palette to force a re-fetch.
+    const refreshHuggingfaceCache = vscode.commands.registerCommand('gpt-token-counter-live.refreshHuggingfaceCache', () => {
+        if (currentProvider !== 'huggingface') {
+            vscode.window.showInformationMessage('Switch to the HuggingFace model family before refreshing its tokenizer cache.');
+            return;
+        }
+        const hfConfig = readHuggingfaceConfigFromVscode();
+        const source = resolveHuggingfaceSource(hfConfig);
+        if (source.kind === 'remote') {
+            removeFileIfExists(getHuggingfaceCacheFilePath(source.safeId, '.json'));
+            removeFileIfExists(getHuggingfaceCacheFilePath(source.safeId, '.config.json'));
+            vscode.window.showInformationMessage(`HuggingFace tokenizer cache cleared for "${source.modelId}". Refetching...`);
+        } else if (source.kind === 'local') {
+            vscode.window.showInformationMessage(`Reloading HuggingFace tokenizer from "${source.path}"...`);
+        } else {
+            vscode.window.showInformationMessage('HuggingFace tokenizer has no model ID or local path configured.');
+            return;
+        }
+        try {
+            initializeEncoderForFamily('huggingface');
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to reload HuggingFace tokenizer: ${error.message}`);
+        }
+        scheduleUpdateTokenCount();
+    });
+
+    context.subscriptions.push(refreshHuggingfaceCache);
 
     const configureHighlights = vscode.commands.registerCommand('gpt-token-counter-live.configureHighlights', async () => {
         loadHighlightColors(context);
@@ -1172,7 +1742,7 @@ function activate(context) {
             loadHighlightColors(context);
 
             refreshTokenDecorations();
-            updateTokenCount();
+            scheduleUpdateTokenCount();
             panel.webview.postMessage({ type: 'colorUpdate', key, value: hexValue });
         };
 
@@ -1191,15 +1761,16 @@ function activate(context) {
 
     // Initial update
     initializeEncoderForFamily(currentProvider);
-    updateTokenCount();
+    scheduleUpdateTokenCount();
     updateHighlightStatusBar();
 }
 
 function deactivate() {
-    if (tokenizerState.encoder) {
+    if (tokenizerState.encoder && typeof tokenizerState.encoder.free === 'function') {
         tokenizerState.encoder.free();
         tokenizerState.encoder = null;
     }
+    tokenizerState.hfTokenizer = null;
 }
 
 module.exports = {
@@ -1210,6 +1781,14 @@ module.exports = {
         resolveUtf16Offset,
         buildNormalizationOffsetMap,
         resolveOriginalOffsetFromNormalized
+    },
+    __hf: {
+        deriveHfSafeId,
+        resolveHuggingfaceSource,
+        reconstructHuggingfaceOffsets,
+        buildHuggingfaceTokenizerFromStrings,
+        huggingfaceTokenizerSupportsHighlight,
+        Tokenizer: HuggingfaceTokenizer
     },
     _test: {
         loadEnabledFilePatterns,

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -1,4 +1,7 @@
 const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
 const vscode = require('vscode');
 
 const extension = require('../../src/extension');
@@ -158,5 +161,259 @@ suite('File Pattern Matching', () => {
 
 	suiteTeardown(() => {
 		setEnabledFilePatterns([]);
+	});
+});
+
+suite('HuggingFace Tokenizer', () => {
+	const {
+		deriveHfSafeId,
+		resolveHuggingfaceSource,
+		reconstructHuggingfaceOffsets,
+		buildHuggingfaceTokenizerFromStrings,
+		huggingfaceTokenizerSupportsHighlight,
+		Tokenizer
+	} = extension.__hf;
+
+	test('deriveHfSafeId readable prefix uses double-dashes for path separators', () => {
+		assert.ok(
+			deriveHfSafeId('Qwen/Qwen2.5-7B-Instruct').startsWith('Qwen--Qwen2.5-7B-Instruct_'),
+			'prefix should mirror the model ID before the hash separator'
+		);
+		assert.ok(
+			deriveHfSafeId('meta-llama/Llama-3-8B').startsWith('meta-llama--Llama-3-8B_'),
+			'prefix should mirror the model ID before the hash separator'
+		);
+	});
+
+	test('deriveHfSafeId scrubs unsafe characters in the readable prefix', () => {
+		assert.ok(deriveHfSafeId('my org/weird name (fork)').startsWith('my_org--weird_name__fork__'));
+		assert.ok(deriveHfSafeId('bedirt/model_v1.0').startsWith('bedirt--model_v1.0_'));
+	});
+
+	test('deriveHfSafeId appends a 12-char hex hash for disambiguation', () => {
+		assert.match(deriveHfSafeId('Qwen/Qwen2.5-7B-Instruct'), /_[0-9a-f]{12}$/);
+		assert.match(deriveHfSafeId('bedirt/model_v1.0'), /_[0-9a-f]{12}$/);
+	});
+
+	test('deriveHfSafeId is injective for IDs that would share a readable prefix', () => {
+		// Both of these previously collapsed to `a--b--c` and clobbered each other in the
+		// cache. The hash suffix must keep them distinct.
+		assert.notStrictEqual(deriveHfSafeId('a/b--c'), deriveHfSafeId('a--b/c'));
+		assert.notStrictEqual(deriveHfSafeId('foo/bar'), deriveHfSafeId('foo--bar'));
+	});
+
+	test('deriveHfSafeId is deterministic for the same input', () => {
+		assert.strictEqual(deriveHfSafeId('Qwen/Qwen2.5-7B-Instruct'), deriveHfSafeId('Qwen/Qwen2.5-7B-Instruct'));
+	});
+
+	test('deriveHfSafeId handles falsy input', () => {
+		assert.strictEqual(deriveHfSafeId(''), '');
+		assert.strictEqual(deriveHfSafeId(null), '');
+		assert.strictEqual(deriveHfSafeId(undefined), '');
+		assert.strictEqual(deriveHfSafeId(42), '');
+	});
+
+	test('resolveHuggingfaceSource picks local path when both present', () => {
+		const both = resolveHuggingfaceSource({
+			localPath: '/abs/path/tokenizer.json',
+			modelId: 'Qwen/Qwen2.5-7B-Instruct'
+		});
+		assert.strictEqual(both.kind, 'local');
+		assert.strictEqual(both.path, '/abs/path/tokenizer.json');
+	});
+
+	test('resolveHuggingfaceSource falls back to model id when local is empty', () => {
+		const remote = resolveHuggingfaceSource({ localPath: '', modelId: 'Qwen/Qwen2.5-7B-Instruct' });
+		assert.strictEqual(remote.kind, 'remote');
+		assert.strictEqual(remote.modelId, 'Qwen/Qwen2.5-7B-Instruct');
+		assert.ok(remote.safeId.startsWith('Qwen--Qwen2.5-7B-Instruct_'));
+		assert.match(remote.safeId, /_[0-9a-f]{12}$/);
+	});
+
+	test('resolveHuggingfaceSource trims whitespace and treats whitespace-only as none', () => {
+		assert.strictEqual(resolveHuggingfaceSource({ modelId: '   ', localPath: '   ' }).kind, 'none');
+		assert.strictEqual(resolveHuggingfaceSource({}).kind, 'none');
+	});
+
+	test('reconstructHuggingfaceOffsets returns empty result for empty ids', () => {
+		const fakeTokenizer = { decode: () => '' };
+		const result = reconstructHuggingfaceOffsets(fakeTokenizer, '', []);
+		assert.deepStrictEqual(result.offsets, []);
+		assert.strictEqual(result.aligned, true);
+	});
+
+	test('reconstructHuggingfaceOffsets flags misalignment when decode does not match source text', () => {
+		// Simulates a SentencePiece-style tokenizer that drops leading whitespace.
+		const fakeTokenizer = {
+			decode(ids) {
+				const pieces = { 10: 'Hello', 11: ' world' };
+				return ids.map((id) => pieces[id]).join('');
+			}
+		};
+		const result = reconstructHuggingfaceOffsets(fakeTokenizer, '  Hello world', [10, 11]);
+		assert.strictEqual(result.aligned, false, 'expected roundtrip mismatch to be flagged');
+	});
+
+	test('reconstructHuggingfaceOffsets produces aligned offsets for a simple byte-level BPE roundtrip', () => {
+		// Mirror the actual @huggingface/tokenizers decode semantics: pass ids and let the
+		// fake look up per-id pieces. Two-arg decode options are accepted but unused here.
+		const pieces = { 1: 'Hello', 2: ' World', 3: '!' };
+		const fakeTokenizer = {
+			decode(ids) {
+				return ids.map((id) => pieces[id]).join('');
+			}
+		};
+		const text = 'Hello World!';
+		const ids = [1, 2, 3];
+		const result = reconstructHuggingfaceOffsets(fakeTokenizer, text, ids);
+		assert.strictEqual(result.aligned, true);
+		assert.deepStrictEqual(result.offsets, [[0, 5], [5, 11], [11, 12]]);
+		// Slicing the source text with each offset yields the matching piece.
+		assert.strictEqual(text.slice(0, 5), 'Hello');
+		assert.strictEqual(text.slice(5, 11), ' World');
+		assert.strictEqual(text.slice(11, 12), '!');
+	});
+
+	test('huggingfaceTokenizerSupportsHighlight returns true for a roundtripping tokenizer', () => {
+		// Byte-level-BPE-style mock: per-id decode yields the corresponding piece, and the
+		// concatenation of all pieces equals the probe text ` Hello, world!\nSecond line.`.
+		const pieces = { 1: ' Hello', 2: ', world!', 3: '\nSecond line.' };
+		const fakeTokenizer = {
+			encode: () => ({ ids: [1, 2, 3] }),
+			decode(ids) {
+				return ids.map((id) => pieces[id]).join('');
+			}
+		};
+		assert.strictEqual(huggingfaceTokenizerSupportsHighlight(fakeTokenizer), true);
+	});
+
+	test('huggingfaceTokenizerSupportsHighlight returns false when decode mutates whitespace', () => {
+		// SentencePiece-style: strip leading whitespace on full decode. The probe text starts
+		// with a space so the round trip will not match.
+		const fakeTokenizer = {
+			encode: () => ({ ids: [1] }),
+			decode() {
+				return 'Hello, world!\nSecond line.';
+			}
+		};
+		assert.strictEqual(huggingfaceTokenizerSupportsHighlight(fakeTokenizer), false);
+	});
+
+	test('huggingfaceTokenizerSupportsHighlight returns false if the tokenizer throws', () => {
+		const fakeTokenizer = {
+			encode() { throw new Error('boom'); },
+			decode() { return ''; }
+		};
+		assert.strictEqual(huggingfaceTokenizerSupportsHighlight(fakeTokenizer), false);
+	});
+
+	test('reconstructHuggingfaceOffsets groups byte-level fragments that individually decode to U+FFFD', () => {
+		// Emulate the real CJK/emoji behavior: single ids decode to `\uFFFD`, but the full group
+		// decodes cleanly. The first id in a group should hold the full slice; follow-up ids
+		// collapse to zero-length so per-token indexing is preserved.
+		const fakeTokenizer = {
+			decode(ids) {
+				const key = ids.join(',');
+				// Individual or short prefixes still produce broken UTF-8 from a byte-level BPE.
+				if (key === '10' || key === '11' || key === '12' || key === '10,11') return '\uFFFD';
+				if (key === '10,11,12') return '\u4F60'; // "你"
+				throw new Error(`unexpected ids ${key}`);
+			}
+		};
+		const text = '\u4F60'; // "你"
+		const result = reconstructHuggingfaceOffsets(fakeTokenizer, text, [10, 11, 12]);
+		assert.strictEqual(result.aligned, true);
+		assert.deepStrictEqual(result.offsets, [[0, 1], [1, 1], [1, 1]]);
+	});
+
+	// Real-tokenizer tests: these download a small gpt-4 tokenizer once and skip with a note
+	// if the network is unreachable. They cover end-to-end encode + roundtrip alignment.
+	suite('with real tokenizer', function () {
+		// Allow extra time for the first-run download.
+		this.timeout(30000);
+
+		const tmpDir = path.join(os.tmpdir(), 'llm-token-counter-hf-test');
+		const tokenizerPath = path.join(tmpDir, 'tokenizer.json');
+		const tokenizerConfigPath = path.join(tmpDir, 'tokenizer_config.json');
+		let tokenizer = null;
+		let fetchFailed = false;
+
+		suiteSetup(async function () {
+			try {
+				fs.mkdirSync(tmpDir, { recursive: true });
+				if (!fs.existsSync(tokenizerPath)) {
+					if (typeof fetch !== 'function') {
+						fetchFailed = true;
+						return;
+					}
+					const baseUrl = 'https://huggingface.co/Xenova/gpt-4/resolve/main';
+					const [tResp, cResp] = await Promise.all([
+						fetch(`${baseUrl}/tokenizer.json`),
+						fetch(`${baseUrl}/tokenizer_config.json`)
+					]);
+					if (!tResp.ok || !cResp.ok) {
+						fetchFailed = true;
+						return;
+					}
+					fs.writeFileSync(tokenizerPath, await tResp.text());
+					fs.writeFileSync(tokenizerConfigPath, await cResp.text());
+				}
+				const tokenizerJson = fs.readFileSync(tokenizerPath, 'utf8');
+				const tokenizerConfigJson = fs.existsSync(tokenizerConfigPath)
+					? fs.readFileSync(tokenizerConfigPath, 'utf8')
+					: '{}';
+				tokenizer = buildHuggingfaceTokenizerFromStrings(tokenizerJson, tokenizerConfigJson);
+			} catch (error) {
+				fetchFailed = true;
+				console.warn('[hf-test] Could not prepare real tokenizer fixture:', error.message);
+			}
+		});
+
+		const ensureTokenizer = function (ctx) {
+			if (!tokenizer || fetchFailed) {
+				ctx.skip();
+			}
+		};
+
+		test('Tokenizer is the constructor exported by @huggingface/tokenizers', function () {
+			ensureTokenizer(this);
+			assert.ok(tokenizer instanceof Tokenizer, 'expected tokenizer to be an instance of Tokenizer');
+		});
+
+		test('ASCII text round-trips cleanly and offsets cover the source', function () {
+			ensureTokenizer(this);
+			const text = 'Hello World! Let us tokenize some text.';
+			const encoded = tokenizer.encode(text, { add_special_tokens: false });
+			const { offsets, aligned } = reconstructHuggingfaceOffsets(tokenizer, text, encoded.ids);
+			assert.strictEqual(aligned, true);
+			assert.strictEqual(offsets.length, encoded.ids.length);
+			// Offsets start at 0, end at text.length.
+			assert.strictEqual(offsets[0][0], 0);
+			assert.strictEqual(offsets[offsets.length - 1][1], text.length);
+			// Offsets reconstruct the original text when sliced and concatenated.
+			let reconstructed = '';
+			for (const [start, end] of offsets) {
+				reconstructed += text.slice(start, end);
+			}
+			assert.strictEqual(reconstructed, text);
+		});
+
+		test('CJK text groups multi-byte tokens into a single aligned slice', function () {
+			ensureTokenizer(this);
+			const text = 'Chinese: \u4F60\u597D\u4E16\u754C';
+			const encoded = tokenizer.encode(text, { add_special_tokens: false });
+			const { offsets, aligned } = reconstructHuggingfaceOffsets(tokenizer, text, encoded.ids);
+			assert.strictEqual(aligned, true, 'CJK reconstruction should still match the source text');
+			assert.strictEqual(offsets[offsets.length - 1][1], text.length);
+		});
+
+		test('encode + offsets with emoji preserves alignment', function () {
+			ensureTokenizer(this);
+			const text = 'Emoji test: \uD83E\uDD9C';
+			const encoded = tokenizer.encode(text, { add_special_tokens: false });
+			const { offsets, aligned } = reconstructHuggingfaceOffsets(tokenizer, text, encoded.ids);
+			assert.strictEqual(aligned, true);
+			assert.strictEqual(offsets[offsets.length - 1][1], text.length);
+		});
 	});
 });

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -195,6 +195,13 @@ suite('HuggingFace Tokenizer', () => {
 		assert.match(deriveHfSafeId('bedirt/model_v1.0'), /_[0-9a-f]{12}$/);
 	});
 
+	test('deriveHfSafeId truncates very long readable prefixes below filename limits', () => {
+		const safeId = deriveHfSafeId(`org/${'very-long-model-name-'.repeat(20)}`);
+		assert.match(safeId, /_[0-9a-f]{12}$/);
+		assert.ok(safeId.startsWith('org--very-long-model-name-'));
+		assert.ok(`${safeId}.config.json`.length < 255, 'cache filename should stay under common filesystem limits');
+	});
+
 	test('deriveHfSafeId is injective for IDs that would share a readable prefix', () => {
 		// Both of these previously collapsed to `a--b--c` and clobbered each other in the
 		// cache. The hash suffix must keep them distinct.
@@ -338,37 +345,82 @@ suite('HuggingFace Tokenizer', () => {
 		let tokenizer = null;
 		let fetchFailed = false;
 
-		suiteSetup(async function () {
-			try {
-				fs.mkdirSync(tmpDir, { recursive: true });
-				if (!fs.existsSync(tokenizerPath)) {
-					if (typeof fetch !== 'function') {
-						fetchFailed = true;
-						return;
+		const removeFixtureFiles = () => {
+			for (const filePath of [tokenizerPath, tokenizerConfigPath]) {
+				try {
+					fs.unlinkSync(filePath);
+				} catch (error) {
+					if (!error || error.code !== 'ENOENT') {
+						throw error;
 					}
-					const baseUrl = 'https://huggingface.co/Xenova/gpt-4/resolve/main';
-					// Each fetch gets its own timeout signal so a stalled proxy aborts
-					// cleanly and the suite skips (via the outer try/catch) instead of
-					// hanging until Mocha's 30s suite timeout fires a hard failure.
-					const [tResp, cResp] = await Promise.all([
-						fetch(`${baseUrl}/tokenizer.json`, { signal: AbortSignal.timeout(15000) }),
-						fetch(`${baseUrl}/tokenizer_config.json`, { signal: AbortSignal.timeout(15000) })
-					]);
-					if (!tResp.ok || !cResp.ok) {
-						fetchFailed = true;
-						return;
-					}
-					fs.writeFileSync(tokenizerPath, await tResp.text());
-					fs.writeFileSync(tokenizerConfigPath, await cResp.text());
 				}
-				const tokenizerJson = fs.readFileSync(tokenizerPath, 'utf8');
-				const tokenizerConfigJson = fs.existsSync(tokenizerConfigPath)
-					? fs.readFileSync(tokenizerConfigPath, 'utf8')
-					: '{}';
-				tokenizer = buildHuggingfaceTokenizerFromStrings(tokenizerJson, tokenizerConfigJson);
+			}
+		};
+
+		const loadFixtureFromDisk = () => {
+			const tokenizerJson = fs.readFileSync(tokenizerPath, 'utf8');
+			const tokenizerConfigJson = fs.existsSync(tokenizerConfigPath)
+				? fs.readFileSync(tokenizerConfigPath, 'utf8')
+				: '{}';
+			return buildHuggingfaceTokenizerFromStrings(tokenizerJson, tokenizerConfigJson);
+		};
+
+		const downloadFixture = async () => {
+			if (typeof fetch !== 'function') {
+				return false;
+			}
+			const baseUrl = 'https://huggingface.co/Xenova/gpt-4/resolve/main';
+			// Each fetch gets its own timeout signal so a stalled proxy aborts
+			// cleanly and the suite skips instead of hanging until Mocha's
+			// 30s suite timeout fires a hard failure.
+			let tResp;
+			let cResp;
+			try {
+				[tResp, cResp] = await Promise.all([
+					fetch(`${baseUrl}/tokenizer.json`, { signal: AbortSignal.timeout(15000) }),
+					fetch(`${baseUrl}/tokenizer_config.json`, { signal: AbortSignal.timeout(15000) })
+				]);
 			} catch (error) {
+				console.warn('[hf-test] Could not fetch real tokenizer fixture:', error.message);
+				return false;
+			}
+			if (!tResp.ok || !cResp.ok) {
+				console.warn(`[hf-test] Could not fetch real tokenizer fixture: tokenizer=${tResp.status}, config=${cResp.status}`);
+				return false;
+			}
+
+			let tokenizerJson;
+			let tokenizerConfigJson;
+			try {
+				tokenizerJson = await tResp.text();
+				tokenizerConfigJson = await cResp.text();
+			} catch (error) {
+				console.warn('[hf-test] Could not read real tokenizer fixture response:', error.message);
+				return false;
+			}
+
+			const downloadedTokenizer = buildHuggingfaceTokenizerFromStrings(tokenizerJson, tokenizerConfigJson);
+			fs.writeFileSync(tokenizerPath, tokenizerJson);
+			fs.writeFileSync(tokenizerConfigPath, tokenizerConfigJson);
+			tokenizer = downloadedTokenizer;
+			return true;
+		};
+
+		suiteSetup(async function () {
+			fs.mkdirSync(tmpDir, { recursive: true });
+			if (fs.existsSync(tokenizerPath)) {
+				try {
+					tokenizer = loadFixtureFromDisk();
+					return;
+				} catch (error) {
+					console.warn('[hf-test] Discarding corrupt real tokenizer fixture and re-downloading:', error.message);
+					removeFixtureFiles();
+				}
+			}
+
+			const downloaded = await downloadFixture();
+			if (!downloaded) {
 				fetchFailed = true;
-				console.warn('[hf-test] Could not prepare real tokenizer fixture:', error.message);
 			}
 		});
 

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -347,9 +347,12 @@ suite('HuggingFace Tokenizer', () => {
 						return;
 					}
 					const baseUrl = 'https://huggingface.co/Xenova/gpt-4/resolve/main';
+					// Each fetch gets its own timeout signal so a stalled proxy aborts
+					// cleanly and the suite skips (via the outer try/catch) instead of
+					// hanging until Mocha's 30s suite timeout fires a hard failure.
 					const [tResp, cResp] = await Promise.all([
-						fetch(`${baseUrl}/tokenizer.json`),
-						fetch(`${baseUrl}/tokenizer_config.json`)
+						fetch(`${baseUrl}/tokenizer.json`, { signal: AbortSignal.timeout(15000) }),
+						fetch(`${baseUrl}/tokenizer_config.json`, { signal: AbortSignal.timeout(15000) })
 					]);
 					if (!tResp.ok || !cResp.ok) {
 						fetchFailed = true;


### PR DESCRIPTION
Adds a `huggingface` model family backed by @huggingface/tokenizers. Loads tokenizer.json from the HuggingFace Hub (fetched once, cached in globalStorage) or from a local absolute path. Token counts are precise; highlighting reconstructs character offsets via decode-based walks that group byte-level-BPE continuation tokens so CJK and emoji stay aligned.

Core pieces:
- New settings: huggingfaceModelId, huggingfaceTokenizerPath (machine scope so a workspace cannot trigger remote loads or direct the extension at arbitrary local files)
- Refresh command: gpt-token-counter-live.refreshHuggingfaceCache lets users force a re-fetch when they suspect upstream tokenizer drift
- Load-time probe: supportsHighlight is set from a roundtrip check so SentencePiece-style tokenizers report highlight unavailable instead of silently clearing on every edit
- Throttled auto-retry after load failures (30s cooldown) so the counter recovers from transient network failures without user intervention
- Atomic cache writes with self-heal on corrupt reads; tmp files cleaned up on write/fsync failure
- Collision-free safeId keys (SHA-256 suffix) so distinct model IDs cannot share a cache file
- AbortSignal.timeout on every fetch so a stalled proxy never pins hfStatus at loading indefinitely
- Skip offset reconstruction in the hot path when highlights are off
- State-transition gating on error notifications so sustained failures do not repop a toast every 30 seconds
- Separate visible-token counter for highlight band alternation so CJK groups do not share colors with adjacent tokens

Bumps: engines.vscode to ^1.82.0 (fetch requirement), package version to 1.5.0, README badges, CHANGELOG and README release notes under 1.5.0 covering HuggingFace, enabledFilePatterns from #11, and the UTF-8/NFKC highlighting fixes from #12.

38 unit tests including real-tokenizer roundtrip coverage against Xenova/gpt-4.